### PR TITLE
Improved usability and flexibility of sync primitives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,6 @@ out/
 .vs/
 
 # CMake devmachine-specific config
-# CMakeSettings.json
+CMakeSettings.json
 
 

--- a/include/mutex.hpp
+++ b/include/mutex.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <basic_types.h>
+#include <irql.h>
 #include <atomic.hpp>
 #include <chrono.hpp>
 #include <type_traits.hpp>
@@ -71,7 +72,6 @@ class recursive_mutex
   recursive_mutex() { KeInitializeMutex(native_handle(), 0); }
 
   void lock() { MyBase::lock_indefinite(); }
-
   void unlock() { KeReleaseMutex(MyBase::native_handle(), false); }
 };
 
@@ -138,32 +138,270 @@ class shared_mutex
   }
 };
 
-// TODO: автонастройка IRQL
-class dpc_spin_lock
-    : public th::details::sync_primitive_base<KSPIN_LOCK> {  // DISPATCH_LEVEL
-                                                             // spin
-                                                             // lock
+namespace th::details {
+template <class LockPolicy>
+class spin_lock_base : non_relocatable {
  public:
-  using MyBase = th::details::sync_primitive_base<KSPIN_LOCK>;
-  using sync_primitive_t = typename MyBase::sync_primitive_t;
-  using native_handle_t = typename MyBase::native_handle_t;
-  using irql_t = KIRQL;
+  using sync_primitive_t = KSPIN_LOCK;
+  using native_handle_t = sync_primitive_t*;
 
  public:
-  using MyBase = th::details::sync_primitive_base<KSPIN_LOCK>;
-  using sync_primitive_t = typename MyBase::sync_primitive_t;
-  using native_handle_t = typename MyBase::native_handle_t;
+  spin_lock_base() noexcept { KeInitializeSpinLock(native_handle()); }
 
- public:
-  dpc_spin_lock() : m_old_irql{KeGetCurrentIrql()} {
-    KeInitializeSpinLock(native_handle());
+  void lock() noexcept { m_lock.get_first().lock(m_lock.get_second()); }
+  void unlock() noexcept { m_lock.get_first().unlock(m_lock.get_second()); }
+
+  native_handle_t native_handle() noexcept {
+    return addressof(m_lock.get_second());
   }
 
-  void lock() { KeAcquireSpinLock(native_handle(), addressof(m_old_irql)); }
-  void unlock() { KeReleaseSpinLock(native_handle(), m_old_irql); }
-
  private:
-  irql_t m_old_irql;
+  compressed_pair<LockPolicy, KSPIN_LOCK> m_lock;
+};
+
+class spin_lock_capture_irql_policy_base {
+ protected:
+  irql_t m_prev_irql;
+};
+
+class spin_lock_apc_policy : spin_lock_capture_irql_policy_base {
+ public:
+  void lock(KSPIN_LOCK& target) noexcept {
+    KeAcquireSpinLock(addressof(target), addressof(m_prev_irql));
+  }
+
+  void unlock(KSPIN_LOCK& target) noexcept {
+    KeReleaseSpinLock(addressof(target), m_prev_irql);
+  }
+};
+
+struct spin_lock_dpc_policy {
+  void lock(KSPIN_LOCK& target) noexcept {
+    KeAcquireSpinLockAtDpcLevel(addressof(target));
+  }
+
+  void unlock(KSPIN_LOCK& target) noexcept {
+    KeReleaseSpinLockFromDpcLevel(addressof(target));
+  }
+};
+
+struct spin_lock_mixed_policy : spin_lock_capture_irql_policy_base {
+  void lock(KSPIN_LOCK& target) noexcept {
+    if (auto irql = get_current_irql(); irql < DISPATCH_LEVEL) {
+      KeAcquireSpinLock(addressof(target), addressof(m_prev_irql));
+    } else {
+      KeAcquireSpinLockAtDpcLevel(addressof(target));
+      m_prev_irql = irql;
+    }
+  }
+
+  void unlock(KSPIN_LOCK& target) noexcept {
+    if (m_prev_irql < DISPATCH_LEVEL) {
+      KeReleaseSpinLock(addressof(target), m_prev_irql);
+    } else {
+      KeReleaseSpinLockFromDpcLevel(addressof(target));
+    }
+  }
+};
+
+class queued_spin_lock_policy_base {
+ protected:
+  KLOCK_QUEUE_HANDLE m_queue_handle;
+};
+
+struct queued_spin_lock_apc_policy : queued_spin_lock_policy_base {
+  void lock(KSPIN_LOCK& target) noexcept {
+    KeAcquireInStackQueuedSpinLock(addressof(target),
+                                   addressof(m_queue_handle));
+  }
+
+  void unlock([[maybe_unused]] KSPIN_LOCK& target) noexcept {
+    KeReleaseInStackQueuedSpinLock(addressof(m_queue_handle));
+  }
+};
+
+struct queued_spin_lock_dpc_policy : queued_spin_lock_policy_base {
+  void lock(KSPIN_LOCK& target) noexcept {
+    KeAcquireInStackQueuedSpinLockAtDpcLevel(addressof(target),
+                                             addressof(m_queue_handle));
+  }
+
+  void unlock([[maybe_unused]] KSPIN_LOCK& target) noexcept {
+    KeReleaseInStackQueuedSpinLockFromDpcLevel(addressof(m_queue_handle));
+  }
+};
+
+struct queued_spin_lock_mixed_policy : queued_spin_lock_policy_base,
+                                       spin_lock_capture_irql_policy_base {
+  void lock(KSPIN_LOCK& target) noexcept {
+    auto irql{get_current_irql()};
+    if (irql < DISPATCH_LEVEL) {
+      KeAcquireInStackQueuedSpinLock(addressof(target),
+                                     addressof(m_queue_handle));
+    } else {
+      KeAcquireInStackQueuedSpinLockAtDpcLevel(addressof(target),
+                                               addressof(m_queue_handle));
+    }
+    m_prev_irql = irql;
+  }
+
+  void unlock([[maybe_unused]] KSPIN_LOCK& target) noexcept {
+    if (m_prev_irql < DISPATCH_LEVEL) {
+      KeReleaseInStackQueuedSpinLock(addressof(m_queue_handle));
+    } else {
+      KeReleaseInStackQueuedSpinLockFromDpcLevel(addressof(m_queue_handle));
+    }
+  }
+};
+
+inline constexpr uint32_t DEVICE_SPIN_LOCK_TAG{0x0}, DPC_SPIN_LOCK_TAG{0x2},
+    APC_SPIN_LOCK_TAG{0x3};
+
+enum class SpinlockType { ApcSpinLock, MixedSpinLock, DpcSpinLock };
+
+template <uint8_t>
+struct spin_lock_selector_base {
+  static constexpr SpinlockType value = SpinlockType::MixedSpinLock;
+};
+
+template <>
+struct spin_lock_selector_base<DEVICE_SPIN_LOCK_TAG> {
+  static constexpr SpinlockType value = SpinlockType::DpcSpinLock;
+};
+
+template <>
+struct spin_lock_selector_base<DPC_SPIN_LOCK_TAG> {
+  static constexpr SpinlockType value = SpinlockType::DpcSpinLock;
+};
+
+template <>
+struct spin_lock_selector_base<APC_SPIN_LOCK_TAG> {
+  static constexpr SpinlockType value = SpinlockType::ApcSpinLock;
+};
+
+template <irql_t MinIrql, irql_t MaxIrql>
+struct spin_lock_selector {
+  static_assert(MinIrql <= MaxIrql, "invalid spinlock type");
+
+  static constexpr SpinlockType value =
+      spin_lock_selector_base<static_cast<uint8_t>(MinIrql <= APC_LEVEL) |
+                              (static_cast<uint8_t>(MaxIrql <= DISPATCH_LEVEL)
+                               << 1)>::value;
+};
+
+template <irql_t MinIrql, irql_t MaxIrql>
+inline constexpr SpinlockType spin_lock_selector_v =
+    spin_lock_selector<MinIrql, MaxIrql>::value;
+}  // namespace th::details
+
+template <irql_t MinIrql = PASSIVE_LEVEL,
+          irql_t MaxIrql = HIGH_LEVEL,
+          th::details::SpinlockType =
+              th::details::spin_lock_selector_v<MinIrql, MaxIrql>>
+struct spin_lock : public th::details::spin_lock_base<
+                       th::details::queued_spin_lock_mixed_policy> {
+  using MyBase =
+      th::details::spin_lock_base<th::details::queued_spin_lock_mixed_policy>;
+  using sync_primitive_t = MyBase::sync_primitive_t;
+  using native_handle_t = MyBase::native_handle_t;
+
+  using MyBase::MyBase;
+
+  using MyBase::lock;
+  using MyBase::unlock;
+
+  using MyBase::native_handle;
+};
+
+template <irql_t MinIrql, irql_t MaxIrql>
+struct spin_lock<MinIrql, MaxIrql, th::details::SpinlockType::ApcSpinLock>
+    : public th::details::spin_lock_base<
+          th::details::queued_spin_lock_apc_policy> {
+  using MyBase =
+      th::details::spin_lock_base<th::details::queued_spin_lock_apc_policy>;
+  using sync_primitive_t = MyBase::sync_primitive_t;
+  using native_handle_t = MyBase::native_handle_t;
+
+  using MyBase::MyBase;
+
+  using MyBase::lock;
+  using MyBase::unlock;
+
+  using MyBase::native_handle;
+};
+
+template <irql_t MinIrql, irql_t MaxIrql>
+struct spin_lock<MinIrql, MaxIrql, th::details::SpinlockType::DpcSpinLock>
+    : public th::details::spin_lock_base<
+          th::details::queued_spin_lock_dpc_policy> {
+  using MyBase =
+      th::details::spin_lock_base<th::details::queued_spin_lock_dpc_policy>;
+  using sync_primitive_t = MyBase::sync_primitive_t;
+  using native_handle_t = MyBase::native_handle_t;
+
+  using MyBase::MyBase;
+
+  using MyBase::lock;
+  using MyBase::unlock;
+
+  using MyBase::native_handle;
+};
+
+template <irql_t MinIrql = PASSIVE_LEVEL,
+          irql_t MaxIrql = HIGH_LEVEL,
+          th::details::SpinlockType =
+              th::details::spin_lock_selector_v<MinIrql, MaxIrql>>
+struct queued_spin_lock : public th::details::spin_lock_base<
+                              th::details::queued_spin_lock_mixed_policy> {
+  using MyBase =
+      th::details::spin_lock_base<th::details::queued_spin_lock_mixed_policy>;
+  using sync_primitive_t = MyBase::sync_primitive_t;
+  using native_handle_t = MyBase::native_handle_t;
+
+  using MyBase::MyBase;
+
+  using MyBase::lock;
+  using MyBase::unlock;
+
+  using MyBase::native_handle;
+};
+
+template <irql_t MinIrql, irql_t MaxIrql>
+struct queued_spin_lock<MinIrql,
+                        MaxIrql,
+                        th::details::SpinlockType::ApcSpinLock>
+    : public th::details::spin_lock_base<
+          th::details::queued_spin_lock_apc_policy> {
+  using MyBase =
+      th::details::spin_lock_base<th::details::queued_spin_lock_apc_policy>;
+  using sync_primitive_t = MyBase::sync_primitive_t;
+  using native_handle_t = MyBase::native_handle_t;
+
+  using MyBase::MyBase;
+
+  using MyBase::lock;
+  using MyBase::unlock;
+
+  using MyBase::native_handle;
+};
+
+template <irql_t MinIrql, irql_t MaxIrql>
+struct queued_spin_lock<MinIrql,
+                        MaxIrql,
+                        th::details::SpinlockType::DpcSpinLock>
+    : public th::details::spin_lock_base<
+          th::details::queued_spin_lock_dpc_policy> {
+  using MyBase =
+      th::details::spin_lock_base<th::details::queued_spin_lock_dpc_policy>;
+  using sync_primitive_t = MyBase::sync_primitive_t;
+  using native_handle_t = MyBase::native_handle_t;
+
+  using MyBase::MyBase;
+
+  using MyBase::lock;
+  using MyBase::unlock;
+
+  using MyBase::native_handle;
 };
 
 class semaphore

--- a/include/smart_pointer.hpp
+++ b/include/smart_pointer.hpp
@@ -189,13 +189,11 @@ class unique_ptr {
 
   operator bool() const noexcept { return static_cast<bool>(get()); }
 
-  add_lvalue_reference_t<Ty> operator*()
-      const& {  //Перегруженный Ty::operator*() способен вызвать
-                //исключение
-    return *get();
-  }
+  add_lvalue_reference_t<Ty> operator*() const& noexcept { return *get(); }
 
-  add_rvalue_reference_t<Ty> operator*() const&& { return move(*get()); }
+  add_rvalue_reference_t<Ty> operator*() const&& noexcept {
+    return move(*get());
+  }
 
   pointer operator->() const noexcept { return m_value.get_second(); }
 


### PR DESCRIPTION
Added lock/unlock policy autoselection to spin_lock and universal lock (mutex/spinlock depends of IRQL) to non-lock-free atomics