### PR TITLE
Introduced condition variables

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -7,12 +7,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(KTL_INCLUDE_DIR "${KTL_DIR}/include")
 
 set(
-	KTL_RUNTIME_HEADER_FILES
+	KTL_HEADER_FILES
 		"algorithm.hpp"
 		"allocator.hpp"
 		"assert.hpp"
 		"atomic.hpp"
 		"chrono.hpp"
+		"condition_variable.h"
 		"driver_base.h"
 		"exception.h"
 		"functional.hpp"

--- a/include/condition_variable.h
+++ b/include/condition_variable.h
@@ -1,0 +1,79 @@
+#pragma once
+#include <atomic.hpp>
+#include <chrono.hpp>
+#include <mutex.hpp>
+#include <type_traits.hpp>
+#include <utility.hpp>
+
+namespace ktl {
+namespace th::details {
+template <class Lockable, class = void>
+struct has_lock : false_type {};
+
+template <class Lockable>
+struct has_lock<Lockable, void_t<decltype(declval<Lockable>().unlock())>>
+    : true_type {};
+
+template <class Lockable, class = void>
+struct has_unlock : false_type {};
+
+template <class Lockable>
+struct has_unlock<Lockable, void_t<decltype(declval<Lockable>().unlock())>>
+    : true_type {};
+
+template <class Lockable>
+inline constexpr bool is_basic_lockable_v =
+    has_lock<Lockable>::value&& has_unlock<Lockable>::value;
+
+template <class Lockable>
+struct basic_lockable_checker {
+  static_assert(is_basic_lockable_v<Lockable>,
+                "Lockable doesn't satisfy requirements of BasicLockable");
+};
+
+class condition_variable_base : non_relocatable {
+ public:
+  void notify_one() noexcept;
+  void notify_all() noexcept;
+
+ protected:
+  sync_event m_event;
+  atomic_size_t m_wait_count{0};
+};
+}  // namespace th::details
+
+struct condition_variable_any : public th::details::condition_variable_base {
+  template <class Lockable>
+  void wait(Lockable& lock) {
+    th::details::basic_lockable_checker<Lockable>{};
+    lock.unlock();
+    ++m_wait_count;
+    m_event.wait();
+    lock.lock();
+  }
+
+  template <class Lockable, class Predicate>
+  void wait(Lockable& lock, Predicate pred) {
+    while (!pred) {
+      wait(lock);
+    }
+  }
+};
+
+struct condition_variable : public th::details::condition_variable_base {
+  template <class Mutex>
+  void wait(unique_lock<Mutex>& lock) {
+    lock.unlock();
+    ++m_wait_count;
+    m_event.wait();
+    lock.lock();
+  }
+
+  template <class Mutex, class Predicate>
+  void wait(unique_lock<Mutex>& lock, Predicate pred) {
+    while (!pred) {
+      wait(lock);
+    }
+  }
+};
+}  // namespace ktl

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ set(KTL_SOURCE_DIR "${KTL_DIR}/src")
 
 set(
 	KTL_SOURCE_FILES
+		"condition_variable.cpp"
 		"exception.cpp"
 		"literals.cpp"
 		"new_delete.cpp"

--- a/src/condition_variable.cpp
+++ b/src/condition_variable.cpp
@@ -1,0 +1,27 @@
+#include "condition_variable.h"
+
+namespace ktl {
+namespace th::details {
+void condition_variable_base::notify_one() noexcept {
+  for (;;) {
+    size_t current_wait_count{0};
+    if (current_wait_count = m_wait_count.load<memory_order_acquire>();
+        !current_wait_count) {
+      break;
+    }
+    if (m_wait_count.compare_exchange_strong(current_wait_count,
+                                             current_wait_count - 1)) {
+      m_event.set();
+      break;
+    }
+  }
+}
+
+void condition_variable_base::notify_all() noexcept {
+  size_t old_wait_count{m_wait_count.exchange(0)};
+  while (old_wait_count--) {
+    m_event.set();
+  }
+}
+}  // namespace th::details
+}  // namespace ktl


### PR DESCRIPTION
A condition variable is an object able to block the calling thread until notified to resume. Now KTL has conditional_variables implemented with KEVENT and atomics. Their compliance with the C ++ Standard is largely based on the logic of the events!