### PR TITLE
Fixed compiling with /GS on the last version of MSVC

### DIFF
--- a/runtime/include/basic_types.h
+++ b/runtime/include/basic_types.h
@@ -23,16 +23,19 @@ using int64_t = long long;
 using uint64_t = unsigned long long;
 using intmax_t = int64_t;
 using uintmax_t = uint64_t;
+using uintptr_t = uint64_t;
 #define BITNESS 64
 #elif defined(_M_IX86)
 using intmax_t = int32_t;
 using uintmax_t = uint32_t;
+using uintptr_t = uint32_t;
 #define BITNESS 32
 #else
 #error Unsupported platform
 #endif
 
 using size_t = decltype(sizeof(int));
+
 
 using nullptr_t = decltype(nullptr);
 using ptrdiff_t = decltype(static_cast<unsigned char*>(nullptr) -

--- a/runtime/include/bugcheck.h
+++ b/runtime/include/bugcheck.h
@@ -42,6 +42,8 @@ enum class BugCheckReason : bugcheck_code_t {
   ExceptionSpecificationNotSupported,
   NoMatchingExceptionHandler,
 
+  BufferSecurityCheckFailure,
+
   AssertionFailure,
   ForbiddenCall,
   StdAbort

--- a/runtime/include/exc_engine/CMakeLists.txt
+++ b/runtime/include/exc_engine/CMakeLists.txt
@@ -8,6 +8,7 @@ set(KTL_EXC_ENGINE_INCLUDE_DIR "${KTL_RUNTIME_INCLUDE_DIR}/exc_engine")
 
 set(
 	KTL_EXC_ENGINE_HEADER_FILES
+		"cookie.h"
 		"frame_handler.h"
 		"member_ptr.h"
 		"rva.hpp"

--- a/runtime/include/exc_engine/cookie.h
+++ b/runtime/include/exc_engine/cookie.h
@@ -1,0 +1,7 @@
+#include <../basic_types.h>
+#include <../crt_attributes.h>
+
+namespace ktl::crt::exc_engine {
+EXTERN_C const uintptr_t __security_cookie;
+EXTERN_C const uintptr_t KERNEL_MODE_ADDRESS_MASK;
+}  // namespace ktl::crt::exc_engine

--- a/runtime/include/exc_engine/frame_handler.h
+++ b/runtime/include/exc_engine/frame_handler.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <../basic_types.h>
 
-namespace ktLLcrt::exc_engine {
+namespace ktl::crt::exc_engine {
 struct dispatcher_context;
 
 win::ExceptionDisposition frame_handler3(

--- a/runtime/src/exc_engine/CMakeLists.txt
+++ b/runtime/src/exc_engine/CMakeLists.txt
@@ -8,6 +8,7 @@ set(KTL_EXC_ENGINE_SOURCE_DIR "${KTL_RUNTIME_SOURCE_DIR}/exc_engine")
 
 set(
 	KTL_EXC_ENGINE_SOURCE_FILES
+		"cookie.cpp"
 		"member_ptr.cpp"
 		"terminate.cpp"
 )

--- a/runtime/src/exc_engine/cookie.cpp
+++ b/runtime/src/exc_engine/cookie.cpp
@@ -1,0 +1,13 @@
+#include <../basic_types.h>
+#include <bugcheck.h>
+#include <cookie.h>
+
+namespace ktl::crt::exc_engine {
+EXTERN_C void FASTCALL __security_check_cookie(uintptr_t ptr) {
+  if (ptr != __security_cookie || (ptr & KERNEL_MODE_ADDRESS_MASK) != 0) {
+    set_termination_context({BugCheckReason::BufferSecurityCheckFailure});
+    terminate();
+  }
+}
+
+}  // namespace ktl::crt::exc_engine

--- a/runtime/src/exc_engine/x64/CMakeLists.txt
+++ b/runtime/src/exc_engine/x64/CMakeLists.txt
@@ -16,6 +16,7 @@ set(
 set(
 	KTL_EXC_X64_SOURCE_FILES
 		"catch.cpp"
+		"gs_canary.cpp"
 		"throw.cpp"
 		"frame_handler3.cpp"
 		"frame_handler4.cpp"

--- a/runtime/src/exc_engine/x64/frame_handler4.cpp
+++ b/runtime/src/exc_engine/x64/frame_handler4.cpp
@@ -93,7 +93,6 @@ EXTERN_C win::ExceptionDisposition __CxxFrameHandler4(
             dispatcher_ctx->image_base));
     terminate_if_not(
         exception_record->flags.has_any_of(win::ExceptionFlag::Unwinding));
-
     return win::ExceptionDisposition::ContinueSearch;
   }
   return frame_handler(exception_record, frame_ptr, cpu_ctx, dispatcher_ctx);

--- a/runtime/src/exc_engine/x64/gs_canary.cpp
+++ b/runtime/src/exc_engine/x64/gs_canary.cpp
@@ -1,0 +1,7 @@
+#include <symbol.hpp>
+#include <seh.hpp>
+
+namespace ktl::crt::exc_engine {
+EXTERN_C const uintptr_t __security_cookie = 0x00002B99'2DDFA232;
+EXTERN_C const uintptr_t KERNEL_MODE_ADDRESS_MASK{0xFFFF'0000'0000'0000ull};
+}  // namespace ktl::crt::exc_engine

--- a/runtime/src/exc_engine/x64/unwind_handler.cpp
+++ b/runtime/src/exc_engine/x64/unwind_handler.cpp
@@ -86,13 +86,11 @@ frame_walk_pdata::frame_walk_pdata(const byte* image_base) noexcept
   terminate_if_not(pe_hdr->machine == 0x8664);
   terminate_if_not(pe_hdr->opt_magic == 0x20b);
   terminate_if_not(pe_hdr->headers_size >=
-                              dos_hdr->image_header.value() +
-                                  sizeof(pe::header_x64));
+                   dos_hdr->image_header.value() + sizeof(pe::header_x64));
   terminate_if_not(pe_hdr->image_size >= pe_hdr->headers_size);
 
   terminate_if_not(pe_hdr->directory_count >= 4);
-  terminate_if_not(
-      (pe_hdr->exception_table.size % sizeof(function)) == 0);
+  terminate_if_not((pe_hdr->exception_table.size % sizeof(function)) == 0);
 
   m_functions = image_base + pe_hdr->exception_table.relative_virtual_address;
   m_function_count = pe_hdr->exception_table.size / sizeof(function);
@@ -100,10 +98,11 @@ frame_walk_pdata::frame_walk_pdata(const byte* image_base) noexcept
 }
 
 uint64_t& frame_walk_context::gp(uint8_t idx) noexcept {
-  int8_t conv[16] = {
+  // Make array static to avoid insertion a __security_check by compiler
+  static constexpr int8_t conv[16]{
       -1, -1, -1, 0, -1, 1, 2, 3, -1, -1, -1, -1, 4, 5, 6, 7,
   };
-  int8_t offs = conv[idx];
+  const int8_t offs = conv[idx];
   if (offs < 0) {
     bugcheck(BugCheckReason::CorruptedEhUnwindData);
   }


### PR DESCRIPTION
Added __security_cookie and __security_check_cookie()