### PR TITLE
`scoped_lock`

### DIFF
--- a/include/mutex.h
+++ b/include/mutex.h
@@ -853,6 +853,12 @@ public:
   scoped_lock(const scoped_lock&) = delete;
   scoped_lock& operator=(const scoped_lock&) = delete;
 }
+
+template<class... Mtxs>
+scoped_lock(Mtxs&...) -> scoped_lock<Mtxs...>
+
+template<class... Mtxs>
+scoped_lock(adopt_lock_tag, Mtxs&...) -> scoped_lock<Mtxs...>;
  
 // TODO: tuple, scoped_lock
 }  // namespace ktl

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -807,7 +807,7 @@ void lock(Mtx1& mtx1, Mtx2& mtx2, MtxNs&... mtxns) {
 }
  
 template<class... Mtxs>
-class scoped_lock {
+class scoped_lock : non_copyable {
 public:
   explicit scoped_lock(Mtxs&... mtxs) : m_mtxs(mtxs...) { 
     ktl::lock(mtxs...);
@@ -816,16 +816,13 @@ public:
   explicit scoped_lock(adopt_lock_tag, Mtxs&... mtxs) : m_mtxs(mtxs...) { /* Don't lock */ }
   
   ~scoped_lock() { apply([](Mtxs&... mtxs) { (..., (void) mtxs.unlock()); }, m_mtxs); }
-  
-  scoped_lock(const scoped_lock&) = delete;
-  scoped_lock& operator=(const scoped_lock&) = delete;
 
 private:
   tuple<Mtxs&...> m_mtxs;
 };
  
 template<class Mtx>
-class scoped_lock<Mtx> {
+class scoped_lock<Mtx> : non_copyable {
 public:
   using mutex_type = Mtx;
   
@@ -835,23 +832,15 @@ public:
   
   ~scoped_lock() { m_mtx.unlock(); }
   
-  scoped_lock(const scoped_lock&) = delete;
-  scoped_lock& operator=(const scoped_lock&) = delete;
-  
 private:
   Mtx& m_mtx;
 }
  
 template<>
-class scoped_lock<> {
+class scoped_lock<> : non_copyable {
 public:
   explicit scoped_lock() = default;
   explicit scoped_lock(adopt_lock_tag) { }
-  
-  ~scoped_lock() = default;
-  
-  scoped_lock(const scoped_lock&) = delete;
-  scoped_lock& operator=(const scoped_lock&) = delete;
 }
 
 template<class... Mtxs>

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -690,30 +690,27 @@ namespace th::details {
  
  template<class... Mtxs, size_t... Idxs>
  void lock_target_from_locks(const int target, index_sequence<Idxs...>, Mtxs&... mtxs) {
-   int ignored[] = {
+   [[maybe_unused]] int ignored[] = {
      ((target == static_cast<int>(Idxs)) ? (((void)mtxs.lock()), 0) : 0)...
    };
-   (void)ignored;
  }
  
  template<class... Mtxs, size_t... Idxs>
  bool try_lock_target_from_locks(const int target, index_sequence<Idxs...>, Mtxs&... mtxs) {
    bool result = false;
    
-   int ignored[] = {
+   [[maybe_unused]] int ignored[] = {
      ((target == static_cast<int>(Idxs)) ? ((result = mtxs.try_lock()), 0) : 0)...
    };
-   (void)ignored;
    
    return result;
  }
  
  template<class... Mtxs, size_t... Idxs>
  void unlock_locks(const int first, const int last, index_sequence<Idxs...>, Mtxs&... mtxs) {
-   int ignored[] = {
+   [[maybe_unused]] int ignored[] = {
      ((first <= static_cast<int>(Idxs) && static_cast<int>(Idxs) < last) ? (((void)mtxs.unlock()), 0) : 0)...
    };
-   (void)ignored;
  }
  
  template<class... Mtxs>

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -848,7 +848,7 @@ public:
   explicit scoped_lock() = default;
   explicit scoped_lock(adopt_lock_tag) { }
   
-  ~scoped_lock() { }
+  ~scoped_lock() = default;
   
   scoped_lock(const scoped_lock&) = delete;
   scoped_lock& operator=(const scoped_lock&) = delete;

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -7,6 +7,7 @@
 #include <type_traits.hpp>
 #include <utility.hpp>
 #include <tuple.hpp>
+#include <thread.h>
 
 #include <ntddk.h>
 

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -855,7 +855,7 @@ public:
 }
 
 template<class... Mtxs>
-scoped_lock(Mtxs&...) -> scoped_lock<Mtxs...>
+scoped_lock(Mtxs&...) -> scoped_lock<Mtxs...>;
 
 template<class... Mtxs>
 scoped_lock(adopt_lock_tag, Mtxs&...) -> scoped_lock<Mtxs...>;

--- a/include/tuple.hpp
+++ b/include/tuple.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <type_traits.hpp>
+#include <functional.hpp>
 #include <utility.hpp>
 
 namespace ktl {
@@ -483,6 +484,22 @@ template <class... LhsTypes, class... RhsTypes>
 constexpr bool operator>=(const tuple<LhsTypes...>& lhs,
                           const tuple<RhsTypes...>& rhs) {
   return !(lhs < rhs);
+}
+  
+namespace tt::details {
+ 
+template<class F, class Tpl, size_t... Idxs>
+constexpr decltype(auto) apply_impl(F&& f, Tpl&& tpl, index_sequence<Idxs...>) {
+  return invoke(forward<F>(f), get<Idxs>(forward<Tpl>(tpl))...);
+}
+  
+} // namespace tt::details
+  
+template<class F, class Tpl>
+constexpr decltype(auto) apply(F&& f, Tpl&& tpl) {
+  using idxs_t = make_index_sequence<
+    tuple_size_v<remove_reference_t<Tpl>>>;
+  return tt::details::apply_impl(forward<F>(f), forward<Tpl>(tpl), idxs_t{});
 }
 
 }  // namespace ktl


### PR DESCRIPTION
Не получилось его вписать в общую иерархию гардов, он сильно отличается от `lock_guard`, `unique_lock` и пр.

Правила для CTAD надо проинспектировать.