### PR TITLE
Handling __finally funclets

### DIFF
--- a/runtime/include/bugcheck.hpp
+++ b/runtime/include/bugcheck.hpp
@@ -33,6 +33,7 @@ enum class BugCheckReason : bugcheck_code_t {
   UnwindingNonCxxFrame,
 
   SehHandlerNotInSafeseh,
+  CorruptedMachineState,
   DestructorThrewDuringUnwind,
   CorruptedExceptionRegistrationChain,
   NoexceptViolation,

--- a/runtime/include/exc_engine/seh.hpp
+++ b/runtime/include/exc_engine/seh.hpp
@@ -2,6 +2,8 @@
 #include <../crt_attributes.hpp>
 #include <flag_set.hpp>
 
+#include <wdm.h>
+
 namespace ktl::crt::exc_engine::win {
 enum class ExceptionFlag : uint32_t {
   NonContinuable = 0x01,
@@ -51,5 +53,6 @@ using x64_frame_handler_t =
                          x64_cpu_context*,
                          void* dispatcher_context);
 
-inline exception_record exc_record_cookie{};
+inline exception_record exc_record_cookie{
+    0, flag_set<ExceptionFlag>{EXCEPTION_UNWIND}};
 }  // namespace ktl::crt::exc_engine::win

--- a/runtime/include/exc_engine/seh.hpp
+++ b/runtime/include/exc_engine/seh.hpp
@@ -51,4 +51,5 @@ using x64_frame_handler_t =
                          x64_cpu_context*,
                          void* dispatcher_context);
 
+inline exception_record exc_record_cookie{};
 }  // namespace ktl::crt::exc_engine::win

--- a/runtime/include/exc_engine/seh.hpp
+++ b/runtime/include/exc_engine/seh.hpp
@@ -2,8 +2,6 @@
 #include <../crt_attributes.hpp>
 #include <flag_set.hpp>
 
-#include <wdm.h>
-
 namespace ktl::crt::exc_engine::win {
 enum class ExceptionFlag : uint32_t {
   NonContinuable = 0x01,
@@ -53,6 +51,5 @@ using x64_frame_handler_t =
                          x64_cpu_context*,
                          void* dispatcher_context);
 
-inline exception_record exc_record_cookie{
-    0, flag_set<ExceptionFlag>{EXCEPTION_UNWIND}};
+inline exception_record exc_record_cookie{0, ExceptionFlag::Unwinding};
 }  // namespace ktl::crt::exc_engine::win

--- a/runtime/include/flag_set.hpp
+++ b/runtime/include/flag_set.hpp
@@ -66,22 +66,23 @@ struct flag_set {
 };
 
 template <typename Enum>
-flag_set<Enum> operator|(flag_set<Enum> lhs, flag_set<Enum> rhs) noexcept {
-  return lhs.value() | rhs.value();
+constexpr auto operator|(flag_set<Enum> lhs, flag_set<Enum> rhs) noexcept {
+  return flag_set<Enum>{lhs.value() | rhs.value()};
 }
 
 template <typename Enum>
-flag_set<Enum> operator&(flag_set<Enum> lhs, flag_set<Enum> rhs) noexcept {
-  return lhs.value() & rhs.value();
+constexpr auto operator&(flag_set<Enum> lhs,
+                                  flag_set<Enum> rhs) noexcept {
+  return flag_set<Enum>{lhs.value() & rhs.value()};
 }
 
 template <typename Enum>
-bool operator==(flag_set<Enum> lhs, flag_set<Enum> rhs) noexcept {
+constexpr bool operator==(flag_set<Enum> lhs, flag_set<Enum> rhs) noexcept {
   return lhs.value() == rhs.value();
 }
 
 template <typename Enum>
-bool operator!=(flag_set<Enum> lhs, flag_set<Enum> rhs) noexcept {
+constexpr bool operator!=(flag_set<Enum> lhs, flag_set<Enum> rhs) noexcept {
   return !(lhs == rhs);
 }
 }  // namespace ktl

--- a/runtime/src/bugcheck.cpp
+++ b/runtime/src/bugcheck.cpp
@@ -1,94 +1,133 @@
-#include <bugcheck.hpp>
 #include <ntddk.h>
+#include <bugcheck.hpp>
+#include <seh.hpp>
 
 namespace ktl {
 namespace crt::details {
-static terminate_handler_t terminate_handler{nullptr};
-static KSPIN_LOCK bugcheck_guard{};
-static Bsod bugcheck_context{
-    BugCheckReason::StdAbort,
-};
+static termination_dispatcher trmnt_disp;
 }  // namespace crt::details
 
 terminate_handler_t get_terminate() noexcept {
-  return static_cast<terminate_handler_t>(InterlockedCompareExchangePointer(
-      reinterpret_cast<volatile PVOID*>(&crt::details::terminate_handler),
-      nullptr, nullptr));
+  return crt::details::trmnt_disp.get_handler();
 }
 
 terminate_handler_t set_terminate(terminate_handler_t terminate) noexcept {
-  return static_cast<terminate_handler_t>(InterlockedExchangePointer(
-      reinterpret_cast<volatile PVOID*>(&crt::details::terminate_handler),
-      terminate));
+  return crt::details::trmnt_disp.set_handler(terminate);
 }
 
 [[noreturn]] void terminate() noexcept {
-  critical_failure();
+  crt::details::trmnt_disp.terminate();
 }
 
-void terminate_if_not(bool cond) noexcept {
-  if (!cond) {
-    critical_failure();
+[[noreturn]] void abort() noexcept {
+  crt::details::trmnt_disp.abort();
+}
+
+namespace crt {
+termination_context set_termination_context(
+    const termination_context& bsod) noexcept {
+  return details::trmnt_disp.set_context(bsod);
+}
+
+void verify_seh(NTSTATUS code, const void* addr, uint32_t flags) noexcept {
+  DbgPrintEx(
+      DPFLTR_DEFAULT_ID, DPFLTR_ERROR_LEVEL,
+      "SEH exception caught with flag EXCEPTION_UNWIND! Code: %x, address %p\n",
+      code, addr);
+  if (const bool unwinding =
+          flag_set<exc_engine::win::ExceptionFlag>{flags}.has_any_of(
+              exc_engine::win::ExceptionFlag::Unwinding);
+      unwinding) {
+    set_termination_context({BugCheckReason::UnwindingNonCxxFrame, code,
+                             reinterpret_cast<bugcheck_arg_t>(addr)});
+    terminate();
   }
 }
 
-[[noreturn]] void critical_failure() noexcept {
-  if (auto terminate_handler = get_terminate(); terminate_handler) {
+void verify_seh_in_cxx_handler(NTSTATUS code,
+                               const void* addr,
+                               uint32_t flags,
+                               uint32_t unwind_info,
+                               const void* image_base) noexcept {
+  DbgPrintEx(
+      DPFLTR_DEFAULT_ID, DPFLTR_ERROR_LEVEL,
+      "SEH exception caught in CXX handler! Code: %x, address %p, function "
+      "unwind info offset: %u, base of image located at %p)\n",
+      code, addr, unwind_info, image_base);
+  if (const bool unwinding =
+          flag_set<exc_engine::win::ExceptionFlag>{flags}.has_any_of(
+              exc_engine::win::ExceptionFlag::Unwinding);
+      unwinding) {
+    set_termination_context({BugCheckReason::UnwindingNonCxxFrame, code,
+                             reinterpret_cast<bugcheck_arg_t>(addr),
+                             unwind_info,
+                             reinterpret_cast<bugcheck_arg_t>(image_base)});
+    terminate();
+  }
+}
+
+namespace details {
+terminate_handler_t termination_dispatcher::get_handler() const noexcept {
+  auto* as_volatile{reinterpret_cast<const volatile PVOID*>(&m_handler)};
+  auto* handler_ptr{const_cast<volatile PVOID*>(as_volatile)};
+  const auto result{
+      InterlockedCompareExchangePointer(handler_ptr, nullptr, nullptr)};
+  return reinterpret_cast<terminate_handler_t>(result);
+}
+
+terminate_handler_t termination_dispatcher::set_handler(
+    terminate_handler_t handler) noexcept {
+  auto* as_volatile{reinterpret_cast<const volatile PVOID*>(&m_handler)};
+  auto* handler_ptr{const_cast<volatile PVOID*>(as_volatile)};
+  const auto prev{InterlockedExchangePointer(handler_ptr, handler)};
+  return reinterpret_cast<terminate_handler_t>(prev);
+}
+
+termination_context termination_dispatcher::set_context(
+    const termination_context& bsod) noexcept {
+  acquire_lock();
+  const termination_context old_context{m_context};
+  m_context = bsod;
+  release_lock();
+  return old_context;
+}
+
+void termination_dispatcher::terminate() const noexcept {
+  if (const auto terminate_handler = get_terminate(); terminate_handler) {
     terminate_handler();
   }
   abort();
 }
 
-[[noreturn]] void abort() noexcept {
-  crt::abort_impl();
+[[noreturn]] void termination_dispatcher::abort() const noexcept {
+  acquire_lock();
+  const auto [reason, arg1, arg2, arg3, arg4]{m_context};
+  KeBugCheckEx(KTL_FAILURE | to_bugcheck_code(reason), arg1, arg2, arg3, arg4);
 }
 
-namespace crt {
-bugcheck_code_t to_bucgcheck_code(BugCheckReason reason) noexcept {
+void termination_dispatcher::acquire_lock() const noexcept {
+  auto* lock_ptr{reinterpret_cast<volatile long*>(&m_spin_lock)};
+  const irql_t prev_irql{raise_irql(HIGH_LEVEL)};
+  while (InterlockedCompareExchange(lock_ptr, 1, 0)) {
+    while (*lock_ptr) {
+      YieldProcessor();
+    }
+  }
+  m_prev_irql = prev_irql;
+}
+
+void termination_dispatcher::release_lock() const noexcept {
+  auto& as_volatile{reinterpret_cast<volatile long&>(m_spin_lock)};
+  const irql_t prev_irql{m_prev_irql};
+  InterlockedExchange(&as_volatile, 0);
+  lower_irql(prev_irql);
+}
+
+bugcheck_code_t termination_dispatcher::to_bugcheck_code(
+    BugCheckReason reason) noexcept {
   return static_cast<bugcheck_code_t>(reason);
 }
 
-Bsod set_termination_context(const Bsod& bsod) noexcept {
-  auto& lock{details::bugcheck_guard};
-  irql_t prev_irql{get_current_irql()};
-
-  if (prev_irql >= DISPATCH_LEVEL) {
-    KeAcquireSpinLockAtDpcLevel(&lock);
-  } else {
-    KeAcquireSpinLock(&lock, &prev_irql);
-  }
-
-  auto& context{details::bugcheck_context};
-  Bsod old_context{context};
-  context = bsod;
-
-  if (prev_irql >= DISPATCH_LEVEL) {
-    KeReleaseSpinLockFromDpcLevel(&lock);
-  } else {
-    KeReleaseSpinLock(&lock, prev_irql);
-  }
-
-  return old_context;
-}
-
-[[noreturn]] void bugcheck(BugCheckReason reason) noexcept {
-  bugcheck(Bsod{reason});
-}
-
-[[noreturn]] void bugcheck(const Bsod& bsod) noexcept {
-  KeBugCheckEx(KTL_FAILURE | to_bucgcheck_code(bsod.reason), bsod.arg1,
-               bsod.arg2, bsod.arg3, bsod.arg4);
-}
-
-[[noreturn]] void abort_impl() noexcept {
-  if (auto& lock = details::bugcheck_guard;
-      get_current_irql() >= DISPATCH_LEVEL) {
-    KeAcquireSpinLockAtDpcLevel(&lock);
-  } else {
-    irql_t dummy;
-    KeAcquireSpinLock(&lock, &dummy);
-  }
-  bugcheck(details::bugcheck_context);
-}
+}  // namespace details
 }  // namespace crt
 }  // namespace ktl

--- a/runtime/src/exc_engine/x64/capture.asm
+++ b/runtime/src/exc_engine/x64/capture.asm
@@ -71,25 +71,31 @@ throw_fr struct
 	p3 qword ?
 	p4 qword ?
 
-	$xmm6  oword ?   ; 0x40
-	$xmm7  oword ?   ; 0x50
-	$xmm8  oword ?   ; 0x60
-	$xmm9  oword ?   ; 0x70
-	$xmm10 oword ?   ; 0x80
-	$xmm11 oword ?   ; 0x90
-	$xmm12 oword ?   ; 0xa0
-	$xmm13 oword ?   ; 0xb0
-	$xmm14 oword ?   ; 0xc0
-	$xmm15 oword ?   ; 0xd0
+	$xmm6  oword ?				; 0x40
+	$xmm7  oword ?				; 0x50
+	$xmm8  oword ?				; 0x60
+	$xmm9  oword ?				; 0x70
+	$xmm10 oword ?				; 0x80
+	$xmm11 oword ?				; 0x90
+	$xmm12 oword ?				; 0xa0
+	$xmm13 oword ?				; 0xb0
+	$xmm14 oword ?				; 0xc0
 
-	$rbx   qword ?   ; 0x00
-	$rbp   qword ?   ; 0x08
-	$rsi   qword ?   ; 0x10
-	$rdi   qword ?   ; 0x18
-	$r12   qword ?   ; 0x20
-	$r13   qword ?   ; 0x28
-	$r14   qword ?   ; 0x30
-	$r15   qword ?   ; 0x38
+	$padding1 qword ?			; 0xd0
+	$rsp_placeholder qword ?	; 0xd8
+	$rip_placeholder qword ?	; 0xe0
+	$padding2 qword ?			; 0xe8
+
+	$xmm15 oword ?				; 0xf0
+
+	$rbx   qword ?				; 0x00
+	$rbp   qword ?				; 0x08
+	$rsi   qword ?				; 0x10
+	$rdi   qword ?				; 0x18
+	$r12   qword ?				; 0x20
+	$r13   qword ?				; 0x28
+	$r14   qword ?				; 0x30
+	$r15   qword ?				; 0x38
 
 	$rip   qword ?
 	$cs    qword ?
@@ -199,7 +205,7 @@ _CxxThrowException proc public frame: __cxx_seh_frame_handler
 
 	; We index via `rax`, which points into the middle of the xmm context.
 	; This makes the offset fit in a signed byte, making the opcodes shorter.
-	base = throw_fr.$xmm10
+	base = throw_fr.$xmm12
 	lea rax, [rsp + base]
 	movdqa [rax - base + throw_fr.$xmm6], xmm6
 	movdqa [rax - base + throw_fr.$xmm7], xmm7
@@ -289,7 +295,7 @@ __cxx_eh_apply_context proc private frame: __cxx_seh_frame_handler
 .savexmm128 xmm15, throw_fr.$xmm15
 .endprolog
 
-	base = throw_fr.$xmm10
+	base = throw_fr.$xmm12
 	lea rax, [rsp + base]
 	movdqa xmm6, [rax - base + throw_fr.$xmm6]
 	movdqa xmm7, [rax - base + throw_fr.$xmm7]
@@ -303,7 +309,7 @@ __cxx_eh_apply_context proc private frame: __cxx_seh_frame_handler
 	movdqa xmm15, [rax - base + throw_fr.$xmm15]
 
 	base = throw_fr.$rdi
-	lea rax, [rax + base - throw_fr.$xmm10]
+	lea rax, [rax + base - throw_fr.$xmm12]
 	mov rbx, [rax - base + throw_fr.$rbx]
 	mov rbp, [rax - base + throw_fr.$rbp]
 	mov rsi, [rax - base + throw_fr.$rsi]

--- a/runtime/src/exc_engine/x64/capture.asm
+++ b/runtime/src/exc_engine/x64/capture.asm
@@ -71,31 +71,32 @@ throw_fr struct
 	p3 qword ?
 	p4 qword ?
 
-	$xmm6  oword ?				; 0x40
-	$xmm7  oword ?				; 0x50
-	$xmm8  oword ?				; 0x60
-	$xmm9  oword ?				; 0x70
-	$xmm10 oword ?				; 0x80
-	$xmm11 oword ?				; 0x90
-	$xmm12 oword ?				; 0xa0
-	$xmm13 oword ?				; 0xb0
-	$xmm14 oword ?				; 0xc0
+	$xmm6  oword ?		; 0x40
+	$xmm7  oword ?		; 0x50
+	$xmm8  oword ?		; 0x60
+	$xmm9  oword ?		; 0x70
+	$xmm10 oword ?		; 0x80
+	$xmm11 oword ?		; 0x90
+	$xmm12 oword ?		; 0xa0
+	$xmm13 oword ?		; 0xb0
+	$xmm14 oword ?		; 0xc0
 
-	$padding1 qword ?			; 0xd0
-	$rsp_placeholder qword ?	; 0xd8
-	$rip_placeholder qword ?	; 0xe0
-	$padding2 qword ?			; 0xe8
+	$padding1	qword ?	; 0xd0
+	$dummy_rsp  qword ?	; 0xd8, used in _CONTEXT: 0x98
 
-	$xmm15 oword ?				; 0xf0
+	$xmm15 oword ?		; 0xf0
 
-	$rbx   qword ?				; 0x00
-	$rbp   qword ?				; 0x08
-	$rsi   qword ?				; 0x10
-	$rdi   qword ?				; 0x18
-	$r12   qword ?				; 0x20
-	$r13   qword ?				; 0x28
-	$r14   qword ?				; 0x30
-	$r15   qword ?				; 0x38
+	$rbx   qword ?		; 0x00
+	$rbp   qword ?		; 0x08
+	$rsi   qword ?		; 0x10
+	$rdi   qword ?		; 0x18
+	$r12   qword ?		; 0x20
+	$r13   qword ?		; 0x28
+	$r14   qword ?		; 0x30
+	$r15   qword ?		; 0x38
+
+	$padding2  qword ?		; 0x40
+	$dummy_rip qword ?		; 0x48, used in _CONTEXT: 0xf8
 
 	$rip   qword ?
 	$cs    qword ?
@@ -182,6 +183,11 @@ _CxxThrowException proc public frame: __cxx_seh_frame_handler
 	push r10
 	.allocstack 8
 
+	push r10		; dummy_rip
+	.allocstack 8
+	push 0			; padding2
+	.allocstack 8
+
 	push r15
 	.allocstack 8
 	push r14
@@ -205,8 +211,9 @@ _CxxThrowException proc public frame: __cxx_seh_frame_handler
 
 	; We index via `rax`, which points into the middle of the xmm context.
 	; This makes the offset fit in a signed byte, making the opcodes shorter.
-	base = throw_fr.$xmm12
+	base = throw_fr.$xmm11
 	lea rax, [rsp + base]
+	mov [rax - base + throw_fr.$dummy_rsp], r11		; dummy_rsp
 	movdqa [rax - base + throw_fr.$xmm6], xmm6
 	movdqa [rax - base + throw_fr.$xmm7], xmm7
 	movdqa [rax - base + throw_fr.$xmm8], xmm8
@@ -217,6 +224,7 @@ _CxxThrowException proc public frame: __cxx_seh_frame_handler
 	movdqa [rax - base + throw_fr.$xmm13], xmm13
 	movdqa [rax - base + throw_fr.$xmm14], xmm14
 	movdqa [rax - base + throw_fr.$xmm15], xmm15
+
 
 	; The dispatcher walks the function frames on the stack and looks for
 	; the C++ catch handler. During the walk it unwinds the frames.
@@ -295,7 +303,7 @@ __cxx_eh_apply_context proc private frame: __cxx_seh_frame_handler
 .savexmm128 xmm15, throw_fr.$xmm15
 .endprolog
 
-	base = throw_fr.$xmm12
+	base = throw_fr.$xmm11
 	lea rax, [rsp + base]
 	movdqa xmm6, [rax - base + throw_fr.$xmm6]
 	movdqa xmm7, [rax - base + throw_fr.$xmm7]
@@ -309,7 +317,7 @@ __cxx_eh_apply_context proc private frame: __cxx_seh_frame_handler
 	movdqa xmm15, [rax - base + throw_fr.$xmm15]
 
 	base = throw_fr.$rdi
-	lea rax, [rax + base - throw_fr.$xmm12]
+	lea rax, [rax + base - throw_fr.$xmm11]
 	mov rbx, [rax - base + throw_fr.$rbx]
 	mov rbp, [rax - base + throw_fr.$rbp]
 	mov rsi, [rax - base + throw_fr.$rsi]

--- a/runtime/src/exc_engine/x64/capture.asm
+++ b/runtime/src/exc_engine/x64/capture.asm
@@ -183,7 +183,7 @@ _CxxThrowException proc public frame: __cxx_seh_frame_handler
 	push r10
 	.allocstack 8
 
-	push r10		; dummy_rip
+	push 0			; dummy_rip
 	.allocstack 8
 	push 0			; padding2
 	.allocstack 8

--- a/runtime/src/exc_engine/x64/catch.cpp
+++ b/runtime/src/exc_engine/x64/catch.cpp
@@ -238,7 +238,7 @@ static const unwind_info* execute_handler(dispatcher_context& ctx,
    * https://docs.microsoft.com/en-us/windows/win32/api/winnt/nf-winnt-rtlvirtualunwind
    */
   constexpr auto handler_mask{flag_set{HandlerInfo::Exception} |
-                              flag_set{HandlerInfo::Exception}};
+                              flag_set{HandlerInfo::Unwind}};
   if (const auto flags = flag_set<HandlerInfo>{unwind_info->flags};
       flags & handler_mask) {
     constexpr auto mask{
@@ -256,7 +256,7 @@ static const unwind_info* execute_handler(dispatcher_context& ctx,
     // Dummy fields
     cpu_ctx.dummy_rsp = mach.rsp;
     cpu_ctx.dummy_rip = mach.rip;
-    // ctx.cookie = (symbol*)mach.rip;
+    ctx.last_instruction = mach.rip;
     ctx.history_table = nullptr;
     ctx.scope_index = 0;
 

--- a/runtime/src/exc_engine/x64/catch.cpp
+++ b/runtime/src/exc_engine/x64/catch.cpp
@@ -6,27 +6,6 @@
 EXTERN_C ktl::crt::exc_engine::symbol __ImageBase;
 
 namespace ktl::crt::exc_engine::x64 {
-EXTERN_C void __cxx_call_catch_handler() noexcept;
-EXTERN_C win::x64_frame_handler_t __cxx_seh_frame_handler;
-EXTERN_C win::x64_frame_handler_t __cxx_call_catch_frame_handler;
-
-EXTERN_C const ktl::byte* __cxx_dispatch_exception(void* exception_object,
-                                                   throw_info const* throw_info,
-                                                   throw_frame& frame) noexcept;
-
-EXTERN_C void __cxx_destroy_exception(catch_info& ci) noexcept;
-
-static bool process_catch_block_unchecked(const byte* image_base,
-                                          flag_set<CatchFlag> adjectives,
-                                          const type_info* match_type,
-                                          void* catch_var,
-                                          void* exception_object,
-                                          const catchable_type_list*) noexcept;
-
-static const unwind_info* execute_handler(dispatcher_context& ctx,
-                                          frame_walk_context& cpu_ctx,
-                                          machine_frame& mach) noexcept;
-
 void* catch_info::get_exception_object() const noexcept {
   if (throw_info_if_owner) {
     return exception_object_or_link;
@@ -51,22 +30,52 @@ const throw_info* catch_info::get_throw_info() const noexcept {
   return nullptr;
 }
 
-void probe_for_exception(const frame_walk_pdata& pdata,
-                         throw_frame& frame) noexcept {
-  auto ctx{make_context(&rethrow_probe_cookie, frame, pdata)};
+static bool process_catch_block_unchecked(
+    const byte* image_base,
+    flag_set<CatchFlag> adjectives,
+    const type_info* match_type,
+    void* catch_var,
+    void* exception_object,
+    const catchable_type_list* catchable_list) noexcept {
+  const auto* catchables = catchable_list->types;
 
-  auto& probe_ctx{frame.ctx};
-  auto& probe_mach = frame.mach;
-  auto& catch_info = frame.catch_info;
-
-  for (;;) {
-    const unwind_info* unwind_info =
-        execute_handler(ctx, probe_ctx, probe_mach);
-    if (catch_info.exception_object_or_link) {
-      break;
+  for (uint32_t idx = 0; idx < catchable_list->count; ++idx) {
+    const catchable_type* catchable = image_base + catchables[idx];
+    if (const type_info* type_descriptor = image_base + catchable->desc;
+        type_descriptor == match_type) {
+      if (!catchable->properties.has_any_of(
+              CatchableProperty::ByReferenceOnly) ||
+          adjectives.has_any_of(CatchFlag::IsReference)) {
+        if (adjectives.has_any_of(CatchFlag::IsReference)) {
+          auto* catch_var_holder{static_cast<void**>(catch_var)};
+          *catch_var_holder = exception_object;
+        } else {
+          if (catchable->properties.has_any_of(
+                  CatchableProperty::IsSimpleType)) {
+            memcpy(catch_var, exception_object, catchable->size);
+          } else if (!catchable->copy_fn) {
+            const auto addr{catchable->offset.apply(
+                reinterpret_cast<uintptr_t>(exception_object))};
+            memcpy(catch_var, reinterpret_cast<void*>(addr), catchable->size);
+          } else if (catchable->properties.has_any_of(
+                         CatchableProperty::HasVirtualBase)) {
+            auto* raw_copy_ctor{
+                const_cast<byte*>(image_base + catchable->copy_fn)};
+            auto* copy_ctor{
+                reinterpret_cast<copy_ctor_virtual_base_t*>(raw_copy_ctor)};
+            copy_ctor(catch_var, exception_object, 1);
+          } else {
+            auto* raw_copy_ctor{
+                const_cast<byte*>(image_base + catchable->copy_fn)};
+            auto* copy_ctor{reinterpret_cast<copy_ctor_t*>(raw_copy_ctor)};
+            copy_ctor(catch_var, exception_object);
+          }
+        }
+        return true;
+      }
     }
-    pdata.unwind(*unwind_info, probe_ctx, probe_mach);
   }
+  return false;
 }
 
 bool process_catch_block(const byte* image_base,
@@ -79,14 +88,16 @@ bool process_catch_block(const byte* image_base,
     return true;
   }
 
-  // Вернёт false, если флаг IsConst, IsVolatile или IsUnaligned есть в наборе
-  // throw, но отсутствует у catch
-  if (throw_info.attributes
-          .bit_intersection<ThrowFlag::IsConst, ThrowFlag::IsVolatile,
-                            ThrowFlag::IsUnaligned>() &
-      adjectives.bit_negation()) {  // Приоритет у оператора ~ выше, чем у &
+  /*
+   * Returns false, if throw has one of IsConst, IsVolatile, or IsUnaligned
+   * flags, and the catch block hasn't
+   */
+  if (throw_info.attributes.bit_intersection<
+          ThrowFlag::IsConst, ThrowFlag::IsVolatile, ThrowFlag::IsUnaligned>() &
+      adjectives.bit_negation()) {
     return false;
   }
+
   return process_catch_block_unchecked(image_base, adjectives, match_type,
                                        catch_var, exception_object,
                                        image_base + throw_info.catchables);
@@ -102,6 +113,14 @@ EXTERN_C win::ExceptionDisposition __cxx_seh_frame_handler(
                exception_record->flags.value());
   }
   return win::ExceptionDisposition::ContinueSearch;
+}
+
+EXTERN_C void __cxx_destroy_exception(catch_info& ci) noexcept {
+  if (ci.throw_info_if_owner && ci.throw_info_if_owner->destroy_exc_obj) {
+    const auto destructor{__ImageBase +
+                          ci.throw_info_if_owner->destroy_exc_obj};
+    destructor(ci.exception_object_or_link);
+  }
 }
 
 EXTERN_C win::ExceptionDisposition __cxx_call_catch_frame_handler(
@@ -149,6 +168,111 @@ EXTERN_C win::ExceptionDisposition __cxx_call_catch_frame_handler(
   return win::ExceptionDisposition::CxxHandler;
 }
 
+frame_handler get_frame_handler(const byte* image_base,
+                                const unwind_info& info,
+                                size_t unwind_node_count) noexcept {
+  /*
+   * Immediately after the array of unwind entries in memory is RVAs to the
+   * exception handler and handler-specific data emitted by the compiler
+   *
+   * union {
+   *      uint32_t exception_handler;
+   *      uint32_t function_entry;
+   * };
+   * uint32_t exception_data[];
+   *
+   * Type of exception handler  Type of the associated data
+   *   __C_specific_handler        Scope table
+   *   __GSHandlerCheck            GS data
+   *   __GSHandlerCheck_SEH        Scope table + GS data
+   *   __CxxFrameHandler3          RVA to FuncInfo
+   *   __CxxFrameHandler4          RVA to FuncInfo
+   *   __GSHandlerCheck_EH         RVA to FuncInfo + GS data
+   *
+   * Also see
+   * https://yurichev.com/mirrors/RE/Recon-2012-Skochinsky-Compiler-Internals.pdf
+   */
+  using handler_rva_t = relative_virtual_address<win::x64_frame_handler_t>;
+
+  const auto* exception_handler_and_data{
+      reinterpret_cast<const byte*>(info.data + unwind_node_count)};
+
+  const auto* handler_rva{
+      reinterpret_cast<const handler_rva_t*>(exception_handler_and_data)};
+  const auto* data{exception_handler_and_data + sizeof(handler_rva_t)};
+
+  return {image_base + *handler_rva, data};
+}
+
+static void prepare_for_non_cxx_handler(dispatcher_context& ctx,
+                                        frame_walk_context& cpu_ctx,
+                                        machine_frame& mach) noexcept {
+  cpu_ctx.dummy_rsp = mach.rsp;
+  cpu_ctx.dummy_rip = mach.rip;
+
+  ctx.last_instruction = mach.rip;
+  ctx.history_table = nullptr;
+
+  /*
+   * We do not yet support the continuation of unwinding if an exception was
+   * thrown in the SEH __finally block (this means that the destructor threw the
+   * exception)
+   */
+  ctx.scope_index = 0;
+}
+
+const unwind_info* execute_handler(dispatcher_context& ctx,
+                                   frame_walk_context& cpu_ctx,
+                                   machine_frame& mach) noexcept {
+  const auto& pdata{*ctx.pdata};
+  const byte* image_base{pdata.image_base()};
+
+  ctx.fn = pdata.find_function_entry(mach.rip);
+  const unwind_info* unwind_info{image_base + ctx.fn->unwind_info};
+
+  constexpr auto handler_mask{flag_set{HandlerInfo::Exception} |
+                              flag_set{HandlerInfo::Unwind}};
+  if (const auto flags = flag_set<HandlerInfo>{unwind_info->flags};
+      flags & handler_mask) {
+
+    // The number of active slots is always odd
+    const auto unwind_slots =
+        (static_cast<size_t>(unwind_info->code_count) + 1ull) & ~1ull;
+
+    auto [handler, extra_data]{
+        get_frame_handler(image_base, *unwind_info, unwind_slots)};
+    crt_assert_with_msg(handler,
+                        "C++ exception must have an associated handler");
+    ctx.extra_data = extra_data;
+
+    auto* frame_ptr{reinterpret_cast<byte*>(
+        unwind_info->frame_reg ? cpu_ctx.gp(unwind_info->frame_reg)
+                               : mach.rsp)};
+
+    prepare_for_non_cxx_handler(ctx, cpu_ctx, mach);
+
+    [[maybe_unused]] auto exc_action{
+        handler(&win::exc_record_cookie, frame_ptr,
+                reinterpret_cast<win::x64_cpu_context*>(&cpu_ctx), &ctx)};
+  }
+  return unwind_info;
+}
+
+void probe_for_exception(const frame_walk_pdata& pdata,
+                         throw_frame& frame) noexcept {
+  auto ctx{make_context(&rethrow_probe_cookie, frame, pdata)};
+  auto& [_, probe_ctx, probe_mach, ci]{frame};
+
+  for (;;) {
+    const unwind_info* unwind_info =
+        execute_handler(ctx, probe_ctx, probe_mach);
+    if (ci.exception_object_or_link) {
+      break;
+    }
+    pdata.unwind(*unwind_info, probe_ctx, probe_mach);
+  }
+}
+
 EXTERN_C const byte* __cxx_dispatch_exception(void* exception_object,
                                               const throw_info* throw_info,
                                               throw_frame& frame) noexcept {
@@ -168,114 +292,5 @@ EXTERN_C const byte* __cxx_dispatch_exception(void* exception_object,
     }
     pdata.unwind(*unwind_info, cpu_ctx, mach);
   }
-}
-
-EXTERN_C void __cxx_destroy_exception(catch_info& ci) noexcept {
-  if (ci.throw_info_if_owner && ci.throw_info_if_owner->destroy_exc_obj) {
-    auto* dtor{__ImageBase + ci.throw_info_if_owner->destroy_exc_obj};
-    dtor(ci.exception_object_or_link);
-  }
-}
-
-static bool process_catch_block_unchecked(
-    const byte* image_base,
-    flag_set<CatchFlag> adjectives,
-    const type_info* match_type,
-    void* catch_var,
-    void* exception_object,
-    const catchable_type_list* catchable_list) noexcept {
-  const auto* catchables = catchable_list->types;
-
-  for (uint32_t idx = 0; idx < catchable_list->count; ++idx) {
-    const catchable_type* catchable = image_base + catchables[idx];
-    const type_info* catchable_type_desc = image_base + catchable->desc;
-    if (catchable_type_desc == match_type) {
-      if (!catchable->properties.has_any_of(
-              CatchableProperty::ByReferenceOnly) ||
-          adjectives.has_any_of(CatchFlag::IsReference)) {
-        if (adjectives.has_any_of(CatchFlag::IsReference)) {
-          auto* catch_var_holder{reinterpret_cast<void**>(catch_var)};
-          *catch_var_holder = exception_object;
-        } else {
-          if (catchable->properties.has_any_of(
-                  CatchableProperty::IsSimpleType)) {
-            memcpy(catch_var, exception_object, catchable->size);
-          } else if (!catchable->copy_fn) {
-            const auto addr{catchable->offset.apply(
-                reinterpret_cast<uintptr_t>(exception_object))};
-            memcpy(catch_var, reinterpret_cast<void*>(addr), catchable->size);
-          } else if (catchable->properties.has_any_of(
-                         CatchableProperty::HasVirtualBase)) {
-            auto* copy_ctor{reinterpret_cast<copy_ctor_virtual_base_t*>(
-                image_base + catchable->copy_fn)};
-            copy_ctor(catch_var, exception_object, 1);
-          } else {
-            auto* copy_ctor{reinterpret_cast<copy_ctor_t*>(image_base +
-                                                           catchable->copy_fn)};
-            copy_ctor(catch_var, exception_object);
-          }
-        }
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-static const unwind_info* execute_handler(dispatcher_context& ctx,
-                                          frame_walk_context& cpu_ctx,
-                                          machine_frame& mach) noexcept {
-  const auto& pdata{*ctx.pdata};
-  const byte* image_base{pdata.image_base()};
-
-  ctx.fn = pdata.find_function_entry(mach.rip);
-  const unwind_info* unwind_info{image_base + ctx.fn->unwind_info};
-
-  /*
-   * UNW_FLAG_EHANDLER 0x1
-   * UNW_FLAG_UHANDLER 0x2
-   * See
-   * https://docs.microsoft.com/en-us/windows/win32/api/winnt/nf-winnt-rtlvirtualunwind
-   */
-  constexpr auto handler_mask{flag_set{HandlerInfo::Exception} |
-                              flag_set{HandlerInfo::Unwind}};
-  if (const auto flags = flag_set<HandlerInfo>{unwind_info->flags};
-      flags & handler_mask) {
-    constexpr auto mask{
-        ~static_cast<size_t>(1)};  // The number of active slots is always odd
-    const auto unwind_slots =
-        (static_cast<size_t>(unwind_info->code_count) + 1ull) & mask;
-    auto* frame_handler =
-        image_base +
-        *reinterpret_cast<
-            const relative_virtual_address<win::x64_frame_handler_t>*>(
-            unwind_info->data + unwind_slots);
-
-    crt_assert(frame_handler);
-
-    // Dummy fields
-    cpu_ctx.dummy_rsp = mach.rsp;
-    cpu_ctx.dummy_rip = mach.rip;
-    ctx.last_instruction = mach.rip;
-    ctx.history_table = nullptr;
-    ctx.scope_index = 0;
-
-    ctx.extra_data = &unwind_info->data[unwind_slots + 2];  // Why 2?
-    byte* frame_ptr = reinterpret_cast<byte*>(
-        unwind_info->frame_reg ? cpu_ctx.gp(unwind_info->frame_reg) : mach.rsp);
-
-    [[maybe_unused]] auto exc_action{
-        frame_handler(&win::exc_record_cookie, frame_ptr,
-                      reinterpret_cast<win::x64_cpu_context*>(&cpu_ctx), &ctx)};
-
-    // MSVC добавляет __GSHandlerCheck() в начало таблицы исключений
-    // Поскольку он всегда возвращает win::ExceptionDisposition::ContinueSearch
-    // в случае успешной проверки, отслеживать exc_action ==
-    // win::ExceptionDisposition::CxxHandler мы не можем
-    // Однако SEH-исключение всё равно не пролетит мимо:
-    // т.к. win::exception_record* != nullptr, в __CxxFrameHandler4 сработает
-    // проверка и система упадёт в BSOD
-  }
-  return unwind_info;
 }
 }  // namespace ktl::crt::exc_engine::x64

--- a/runtime/src/exc_engine/x64/catch.hpp
+++ b/runtime/src/exc_engine/x64/catch.hpp
@@ -5,6 +5,7 @@
 #pragma once
 #include <cpu_context.hpp>
 #include <exception_info.hpp>
+#include <seh.hpp>
 #include <symbol.hpp>
 
 namespace ktl::crt::exc_engine::x64 {
@@ -21,10 +22,10 @@ struct catch_info {
   byte* primary_frame_ptr;
   void* exception_object_or_link;
   const throw_info* throw_info_if_owner;
-  uint64_t unwind_context{0};
+  uint64_t unwind_context;
 
-  void* get_exception_object() const noexcept;
-  const throw_info* get_throw_info() const noexcept;
+  [[nodiscard]] void* get_exception_object() const noexcept;
+  [[nodiscard]] const throw_info* get_throw_info() const noexcept;
 };
 
 struct throw_frame {
@@ -42,6 +43,11 @@ struct catch_frame {
   catch_info catch_info;
 };
 
+struct frame_handler {
+  win::x64_frame_handler_t* handler;
+  const void* data;
+};
+
 void probe_for_exception(const frame_walk_pdata& pdata,
                          throw_frame& frame) noexcept;
 
@@ -52,6 +58,6 @@ bool process_catch_block(
     void* catch_var,
     void* exception_object,
     const throw_info&
-        throw_info) noexcept;  // Согласно Стандарту, конструктор копирования
-                               // исключения не имеет права бросить исключение
+        throw_info) noexcept;  // According to the C++ Standard, copy c-tor of
+                               // exception can't throw
 }  // namespace ktl::crt::exc_engine::x64

--- a/runtime/src/exc_engine/x64/cpu_context.hpp
+++ b/runtime/src/exc_engine/x64/cpu_context.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <member_ptr.hpp>
-#include <flag_set.hpp>
 #include <rva.hpp>
 
 namespace ktl::crt::exc_engine::x64 {
@@ -55,6 +54,8 @@ struct function {
 
 ALIGN(16) struct xmm_register { unsigned char data[16]; };
 
+// Marked offsets are used by the nt!__C_specific_handler
+
 struct frame_walk_context {
   xmm_register xmm6;
   xmm_register xmm7;
@@ -65,7 +66,12 @@ struct frame_walk_context {
   xmm_register xmm12;
   xmm_register xmm13;
   xmm_register xmm14;
-  xmm_register xmm15;
+
+  uint64_t padding;          // 16-byte aligned
+  /*0x98*/ uint64_t rsp;     // 8-byte aligned
+  /*0xa0*/ const byte* rip;  // 8-byte aligned
+
+  xmm_register xmm15;        // 16-byte aligned
 
   uint64_t rbx;
   uint64_t rbp;
@@ -77,7 +83,11 @@ struct frame_walk_context {
   uint64_t r15;
 
   uint64_t& gp(uint8_t idx) noexcept;
+
 };
+
+static_assert(offsetof(frame_walk_context, rsp) == 0x98);
+static_assert(offsetof(frame_walk_context, rip) == 0xa0);
 
 struct machine_frame {
   const byte* rip;

--- a/runtime/src/exc_engine/x64/cpu_context.hpp
+++ b/runtime/src/exc_engine/x64/cpu_context.hpp
@@ -28,7 +28,7 @@ struct unwind_info {
   uint8_t version : 3;
   uint8_t flags : 5;
   uint8_t prolog_size;
-  uint8_t unwind_code_count;
+  uint8_t code_count;
   uint8_t frame_reg : 4;
   uint8_t frame_reg_disp : 4;
   union {
@@ -107,7 +107,7 @@ class frame_walk_pdata {
 
   static frame_walk_pdata for_this_image() noexcept;
 
-  const byte* image_base() const noexcept;
+  [[nodiscard]] const byte* image_base() const noexcept;
   bool contains_address(const byte* addr) const noexcept;
   const function* find_function_entry(const byte* addr) const noexcept;
 

--- a/runtime/src/exc_engine/x64/cpu_context.hpp
+++ b/runtime/src/exc_engine/x64/cpu_context.hpp
@@ -101,9 +101,9 @@ class frame_walk_pdata {
   bool contains_address(const byte* addr) const noexcept;
   const function* find_function_entry(const byte* addr) const noexcept;
 
-  void unwind(unwind_info const& unwind_info,
+  static void unwind(const unwind_info& unwind_info,
               frame_walk_context& ctx,
-              machine_frame& mach) const noexcept;
+              machine_frame& mach)noexcept;
 
  private:
   const byte* m_image_base;

--- a/runtime/src/exc_engine/x64/cpu_context.hpp
+++ b/runtime/src/exc_engine/x64/cpu_context.hpp
@@ -67,11 +67,10 @@ struct frame_walk_context {
   xmm_register xmm13;
   xmm_register xmm14;
 
-  uint64_t padding;          // 16-byte aligned
-  /*0x98*/ uint64_t rsp;     // 8-byte aligned
-  /*0xa0*/ const byte* rip;  // 8-byte aligned
+  uint64_t padding1;            // 16-byte aligned
+  /*0x98*/ uint64_t dummy_rsp;  // 8-byte aligned
 
-  xmm_register xmm15;        // 16-byte aligned
+  xmm_register xmm15;           // 16-byte aligned
 
   uint64_t rbx;
   uint64_t rbp;
@@ -82,12 +81,17 @@ struct frame_walk_context {
   uint64_t r14;
   uint64_t r15;
 
+  uint64_t padding2;               // 16-byte aligned
+  /*0xf8*/ const byte* dummy_rip;  // 8-byte aligned
+
   uint64_t& gp(uint8_t idx) noexcept;
 
 };
 
-static_assert(offsetof(frame_walk_context, rsp) == 0x98);
-static_assert(offsetof(frame_walk_context, rip) == 0xa0);
+static_assert(offsetof(frame_walk_context, dummy_rsp) == 0x98);
+static_assert(offsetof(frame_walk_context, dummy_rip) == 0xf8);
+
+constexpr int x = sizeof(frame_walk_context);
 
 struct machine_frame {
   const byte* rip;

--- a/runtime/src/exc_engine/x64/cpu_context.hpp
+++ b/runtime/src/exc_engine/x64/cpu_context.hpp
@@ -38,24 +38,14 @@ struct unwind_info {
 };
 
 struct function {
-  /* 0x00 */ relative_virtual_address<const byte> begin;
-  /* 0x04 */ relative_virtual_address<const byte> end;
-  /* 0x08 */ relative_virtual_address<const unwind_info> unwind_info;
+  /*0x00*/ relative_virtual_address<const byte> begin;
+  /*0x04*/ relative_virtual_address<const byte> end;
+  /*0x08*/ relative_virtual_address<const unwind_info> unwind_info;
 };
-
-/*struct frame_info_t
-{
-        relative_virtual_address<void const> function;
-        relative_virtual_address<win32_frame_handler_t> exception_routine;
-        relative_virtual_address<void const> extra_data;
-        relative_virtual_address<void const> rip;
-        uint64_t frame_ptr;
-};*/
 
 ALIGN(16) struct xmm_register { unsigned char data[16]; };
 
 // Marked offsets are used by the nt!__C_specific_handler
-
 struct frame_walk_context {
   xmm_register xmm6;
   xmm_register xmm7;
@@ -121,7 +111,4 @@ class frame_walk_pdata {
   uint32_t m_function_count;
   uint32_t m_image_size;
 };
-
 }  // namespace ktl::crt::exc_engine::x64
-
-#pragma once

--- a/runtime/src/exc_engine/x64/exception_info.hpp
+++ b/runtime/src/exc_engine/x64/exception_info.hpp
@@ -62,7 +62,7 @@ enum class ThrowFlag : uint32_t {
 
 struct throw_info {
   flag_set<ThrowFlag> attributes;
-  relative_virtual_address<void __fastcall(void*)> destroy_exc_obj;
+  relative_virtual_address<void FASTCALL(void*)> destroy_exc_obj;
   relative_virtual_address<int(...)> compat_fn;
   relative_virtual_address<const catchable_type_list> catchables;
 };

--- a/runtime/src/exc_engine/x64/exception_info.hpp
+++ b/runtime/src/exc_engine/x64/exception_info.hpp
@@ -4,9 +4,8 @@
 #include <rva.hpp>
 
 namespace ktl::crt::exc_engine::x64 {
-// Also see
+// See all possible flags at
 // https://docs.microsoft.com/en-us/windows/win32/api/winnt/nf-winnt-rtlvirtualunwind
-
 enum class HandlerInfo {
   Exception = 0x1,
   Unwind = 0x2,
@@ -96,11 +95,11 @@ struct catch_handler {
 };
 
 struct try_block {
-  /* 0x00 */ int32_t try_low;
-  /* 0x04 */ int32_t try_high;
-  /* 0x08 */ int32_t catch_high;
-  /* 0x0c */ int32_t catch_count;
-  /* 0x10 */ relative_virtual_address<const catch_handler> catch_handlers;
+  /*0x00*/ int32_t try_low;
+  /*0x04*/ int32_t try_high;
+  /*0x08*/ int32_t catch_high;
+  /*0x0c*/ int32_t catch_count;
+  /*0x10*/ relative_virtual_address<const catch_handler> catch_handlers;
 };
 
 struct eh_region {
@@ -124,26 +123,23 @@ enum class EhFlag : uint32_t {
 };
 
 struct function_eh_info {
-  /* 0x00 */ uint32_t magic;  // MSVC's magic number
-  /* 0x04 */ uint32_t state_count;
-  /* 0x08 */ relative_virtual_address<const unwind_graph_edge> unwind_graph;
-  /* 0x0c */ int32_t try_block_count;
-  /* 0x10 */ relative_virtual_address<const try_block> try_blocks;
-  /* 0x14 */ uint32_t region_count;
-  /* 0x18 */ relative_virtual_address<const eh_region> regions;
-  /* 0x1c */ relative_virtual_address<eh_node> eh_node_offset;
+  /*0x00*/ uint32_t magic;  // MSVC's magic number
+  /*0x04*/ uint32_t state_count;
+  /*0x08*/ relative_virtual_address<const unwind_graph_edge> unwind_graph;
+  /*0x0c*/ int32_t try_block_count;
+  /*0x10*/ relative_virtual_address<const try_block> try_blocks;
+  /*0x14*/ uint32_t region_count;
+  /*0x18*/ relative_virtual_address<const eh_region> regions;
+  /*0x1c*/ relative_virtual_address<eh_node> eh_node_offset;
 
   // `magic_num >= 0x19930521`
-  /* 0x20 */ uint32_t es_types;
+  /*0x20*/ uint32_t es_types;
 
   // `magic_num >= 0x19930522`
-  /* 0x24 */ flag_set<EhFlag> eh_flags;
+  /*0x24*/ flag_set<EhFlag> eh_flags;
 };
 
 struct eh_handler_data {
   relative_virtual_address<const function_eh_info> eh_info;
 };
-
 }  // namespace ktl::crt::exc_engine::x64
-
-#pragma once

--- a/runtime/src/exc_engine/x64/exception_info.hpp
+++ b/runtime/src/exc_engine/x64/exception_info.hpp
@@ -4,11 +4,13 @@
 #include <rva.hpp>
 
 namespace ktl::crt::exc_engine::x64 {
+enum class HandlerInfo {
+    Exception = 0x1,
+    Unwind = 0x2,
+    HasAlignment = 0x4,
+};
 
 struct gs_handler_data {
-  static constexpr uint32_t EHANDLER = 1;
-  static constexpr uint32_t UHANDLER = 2;
-  static constexpr uint32_t HAS_ALIGNMENT = 4;
   static constexpr uint32_t COOKIE_OFFSET_MASK = ~7u;
 
   uint32_t cookie_offset;
@@ -68,10 +70,10 @@ struct throw_info {
 };
 
 enum class CatchFlag : uint32_t {
-  IsConst = 1,
-  IsVolatile = 2,
-  IsUnaligned = 4,
-  IsReference = 8,
+  IsConst = 0x1,
+  IsVolatile = 0x2,
+  IsUnaligned = 0x4,
+  IsReference = 0x8,
   IsResumable = 0x10,
   IsEllipsis = 0x40,
   IsBadAllocCompat = 0x80,

--- a/runtime/src/exc_engine/x64/exception_info.hpp
+++ b/runtime/src/exc_engine/x64/exception_info.hpp
@@ -4,10 +4,13 @@
 #include <rva.hpp>
 
 namespace ktl::crt::exc_engine::x64 {
+// Also see
+// https://docs.microsoft.com/en-us/windows/win32/api/winnt/nf-winnt-rtlvirtualunwind
+
 enum class HandlerInfo {
-    Exception = 0x1,
-    Unwind = 0x2,
-    HasAlignment = 0x4,
+  Exception = 0x1,
+  Unwind = 0x2,
+  HasAlignment = 0x4,
 };
 
 struct gs_handler_data {

--- a/runtime/src/exc_engine/x64/frame_handler3.cpp
+++ b/runtime/src/exc_engine/x64/frame_handler3.cpp
@@ -14,7 +14,7 @@ static win::ExceptionDisposition frame_handler(
     win::exception_record*,
     byte* frame_ptr,
     win::x64_cpu_context*,
-    x64::dispatcher_context* dispatcher_context) noexcept;
+    dispatcher_context* dispatcher_context) noexcept;
 
 EXTERN_C win::ExceptionDisposition __CxxFrameHandler3(
     win::exception_record* exception_record,
@@ -31,9 +31,9 @@ EXTERN_C win::ExceptionDisposition __CxxFrameHandler3(
   return frame_handler(exception_record, frame_ptr, cpu_ctx, dispatcher_ctx);
 }
 
-EXTERN_C ktl::crt::exc_engine::win::ExceptionDisposition __GSHandlerCheck_EH(
-    ktl::crt::exc_engine::win::exception_record* exception_record,
-    ktl::byte* frame_ptr,
+EXTERN_C win::ExceptionDisposition __GSHandlerCheck_EH(
+    win::exception_record* exception_record,
+    byte* frame_ptr,
     win::x64_cpu_context* cpu_ctx,
     dispatcher_context* ctx) noexcept {
   /*No cookie check :( */
@@ -44,7 +44,7 @@ static win::ExceptionDisposition frame_handler(
     win::exception_record*,
     byte* frame_ptr,
     win::x64_cpu_context*,
-    x64::dispatcher_context* dispatcher_context) noexcept {
+    dispatcher_context* dispatcher_context) noexcept {
   if (dispatcher_context->cookie == &x64::rethrow_probe_cookie) {
     return win::ExceptionDisposition::CxxHandler;
   }
@@ -72,10 +72,9 @@ static win::ExceptionDisposition frame_handler(
   int32_t home_block_index;
 
   if (primary_frame_ptr < frame_ptr) {
-    auto pc_rva{make_rva(reinterpret_cast<const byte*>(throw_frame->mach.rip),
-                         image_base)};
+    const auto pc_rva{make_rva(throw_frame->mach.rip, image_base)};
 
-    auto regions = image_base + eh_info->regions;
+    const auto regions = image_base + eh_info->regions;
     state = regions[eh_info->region_count - 1].state;
     for (uint32_t i = 1; i != eh_info->region_count; ++i) {
       if (pc_rva < regions[i].first_ip) {
@@ -97,8 +96,8 @@ static win::ExceptionDisposition frame_handler(
     // Identify the funclet we're currently in. If we're in a catch
     // funclet, locate the primary frame ptr and cache everything.
     for (; home_block_index > -1; --home_block_index) {
-      const auto& try_block{try_blocks[home_block_index]};
-      if (try_block.try_high < state && state <= try_block.catch_high) {
+      if (const auto& try_block = try_blocks[home_block_index];
+          try_block.try_high < state && state <= try_block.catch_high) {
         if (primary_frame_ptr < frame_ptr) {
           const auto* catch_handlers{image_base + try_block.catch_handlers};
           for (int32_t idx = 0; idx < try_block.catch_count; ++idx) {
@@ -133,9 +132,8 @@ static win::ExceptionDisposition frame_handler(
   const x64::catch_handler* target_catch_handler = nullptr;
   for (int32_t idx = home_block_index + 1;
        !target_catch_handler && idx < eh_info->try_block_count; ++idx) {
-    const auto& try_block{try_blocks[idx]};
-
-    if (try_block.try_low <= state && state <= try_block.try_high) {
+    if (const auto& try_block = try_blocks[idx];
+        try_block.try_low <= state && state <= try_block.try_high) {
       if (try_block.try_low < funclet_low_state) {
         continue;
       }
@@ -188,12 +186,12 @@ static win::ExceptionDisposition frame_handler(
     const auto& edge{unwind_graph[state]};
     state = edge.next;
     if (edge.cleanup_handler) {
-      byte const* funclet = image_base + edge.cleanup_handler;
-      using fn_type = uintptr_t(byte const* funclet, byte const* frame_ptr);
-      (void)((fn_type*)funclet)(funclet, frame_ptr); // TODO: Fix C-style cast
+      const auto raw_funclet{const_cast<byte*>(image_base + edge.cleanup_handler)};
+      using cleanup_handler_t = uintptr_t(const byte*, const byte*);
+      const auto cleanup_handler{reinterpret_cast<cleanup_handler_t*>(raw_funclet)};
+      cleanup_handler(raw_funclet, frame_ptr); 
     }
   }
-
   return win::ExceptionDisposition::CxxHandler;
 }
 }  // namespace ktl::crt::exc_engine::x64

--- a/runtime/src/exc_engine/x64/frame_handler3.cpp
+++ b/runtime/src/exc_engine/x64/frame_handler3.cpp
@@ -190,7 +190,7 @@ static win::ExceptionDisposition frame_handler(
     if (edge.cleanup_handler) {
       byte const* funclet = image_base + edge.cleanup_handler;
       using fn_type = uintptr_t(byte const* funclet, byte const* frame_ptr);
-      (void)((fn_type*)funclet)(funclet, frame_ptr);
+      (void)((fn_type*)funclet)(funclet, frame_ptr); // TODO: Fix C-style cast
     }
   }
 

--- a/runtime/src/exc_engine/x64/frame_handler4.cpp
+++ b/runtime/src/exc_engine/x64/frame_handler4.cpp
@@ -103,8 +103,8 @@ EXTERN_C win::ExceptionDisposition __CxxFrameHandler4(
 }
 
 EXTERN_C win::ExceptionDisposition __GSHandlerCheck_EH4(
-    ktl::crt::exc_engine::win::exception_record* exception_record,
-    ktl::byte* frame_ptr,
+    win::exception_record* exception_record,
+    byte* frame_ptr,
     [[maybe_unused]] win::x64_cpu_context* cpu_ctx,
     dispatcher_context* ctx) noexcept {
   // No cookie check :(

--- a/runtime/src/exc_engine/x64/frame_handler4.cpp
+++ b/runtime/src/exc_engine/x64/frame_handler4.cpp
@@ -92,7 +92,7 @@ EXTERN_C win::ExceptionDisposition __CxxFrameHandler4(
     byte* frame_ptr,
     win::x64_cpu_context* cpu_ctx,
     dispatcher_context* dispatcher_ctx) noexcept {
-  if (exception_record) {
+  if (exception_record && exception_record->code != KTL_FAILURE) {
     KdPrint(
         ("SEH exception caught in CXX handler! Code: %x, address %p (in "
          "function [%u - %u, unwind info: %u], module starts at %p)\n",
@@ -111,7 +111,7 @@ EXTERN_C win::ExceptionDisposition __GSHandlerCheck_EH4(
     ktl::byte* frame_ptr,
     [[maybe_unused]] win::x64_cpu_context* cpu_ctx,
     dispatcher_context* ctx) noexcept {
-  /*No cookie check :( */
+  // No cookie check :(
   // We assume that the compiler will use only __GSHandlerCheck_SEH for SEH
   // exceptions and therefore don't check exception_record
   return __CxxFrameHandler4(exception_record, frame_ptr, cpu_ctx, ctx);
@@ -357,7 +357,7 @@ static int32_t lookup_region(const fh4::info* eh_info,
   const uint8_t* p = image_base + eh_info->regions;
 
   int32_t state = -1;
-  uint32_t region_count = read_unsigned(&p);
+  const uint32_t region_count = read_unsigned(&p);
   relative_virtual_address<const byte> fn_rva = 0;
   for (uint32_t idx = 0; idx != region_count; ++idx) {
     fn_rva += read_unsigned(&p);

--- a/runtime/src/exc_engine/x64/throw.cpp
+++ b/runtime/src/exc_engine/x64/throw.cpp
@@ -4,7 +4,10 @@ namespace ktl::crt::exc_engine::x64 {
 dispatcher_context make_context(symbol* cookie,
                                 throw_frame& frame,
                                 const frame_walk_pdata& pdata) noexcept {
-  dispatcher_context ctx{frame.mach.rip, pdata.image_base(), nullptr, &pdata, &frame};
+  dispatcher_context ctx{};
+  ctx.image_base = pdata.image_base();
+  ctx.pdata = &pdata;
+  ctx.throw_frame = &frame;
   ctx.cookie = cookie;
   return ctx;
 }

--- a/runtime/src/exc_engine/x64/throw.cpp
+++ b/runtime/src/exc_engine/x64/throw.cpp
@@ -1,9 +1,11 @@
 #include <throw.hpp>
 
 namespace ktl::crt::exc_engine::x64 {
-dispatcher_context make_context(symbol* cookie_,
-                                throw_frame& frame_,
-                                const frame_walk_pdata& pdata_) noexcept {
-  return {cookie_, pdata_.image_base(), nullptr, &pdata_, &frame_};
+dispatcher_context make_context(symbol* cookie,
+                                throw_frame& frame,
+                                const frame_walk_pdata& pdata) noexcept {
+  dispatcher_context ctx{frame.mach.rip, pdata.image_base(), nullptr, &pdata, &frame};
+  ctx.cookie = cookie;
+  return ctx;
 }
 }  // namespace ktl::crt::exc_engine::x64

--- a/runtime/src/exc_engine/x64/throw.hpp
+++ b/runtime/src/exc_engine/x64/throw.hpp
@@ -6,12 +6,10 @@
 
 #include <catch.hpp>
 #include <cpu_context.hpp>
-#include <exception_info.hpp>
-#include <rva.hpp>
 #include <symbol.hpp>
 
 namespace ktl::crt::exc_engine::x64 {
-// Marked offsets are used in nt!__GSHandlerCheck
+// Marked offsets are used by the nt!__GSHandlerCheck
 struct dispatcher_context {
   symbol* cookie;
   /*0x8*/ const byte* image_base;

--- a/runtime/src/exc_engine/x64/throw.hpp
+++ b/runtime/src/exc_engine/x64/throw.hpp
@@ -11,7 +11,7 @@
 #include <symbol.hpp>
 
 namespace ktl::crt::exc_engine::x64 {
-// Отмеченные оффсеты используются в __GSHandlerCheck()
+// Marked offsets are used in nt!__GSHandlerCheck
 struct dispatcher_context {
   symbol* cookie;
   /*0x8*/ const byte* image_base;

--- a/runtime/src/exc_engine/x64/throw.hpp
+++ b/runtime/src/exc_engine/x64/throw.hpp
@@ -9,16 +9,18 @@
 #include <symbol.hpp>
 
 namespace ktl::crt::exc_engine::x64 {
-// Marked offsets are used by the nt!__GSHandlerCheck
+// Marked offsets are used by the nt!__GSHandlerCheck and nt!__C_speficic_handler
 struct dispatcher_context {
   symbol* cookie;
   /*0x8*/ const byte* image_base;
-  /*0x16*/ const function* fn;
+  /*0x10*/ const function* fn;
   const frame_walk_pdata* pdata;
   throw_frame* throw_frame;
   void* padding;
   const byte* handler;
-  /*0x56*/ const void* extra_data;
+  /*0x38*/ const void* extra_data;
+  void* history_table;
+  uint32_t scope_index;
 };
 
 dispatcher_context make_context(symbol* cookie_,

--- a/runtime/src/exc_engine/x64/throw.hpp
+++ b/runtime/src/exc_engine/x64/throw.hpp
@@ -11,7 +11,7 @@
 namespace ktl::crt::exc_engine::x64 {
 // Marked offsets are used by the nt!__GSHandlerCheck and nt!__C_speficic_handler
 struct dispatcher_context {
-  symbol* cookie;
+  /*0x0*/ const byte* last_instruction;
   /*0x8*/ const byte* image_base;
   /*0x10*/ const function* fn;
   const frame_walk_pdata* pdata;
@@ -21,6 +21,7 @@ struct dispatcher_context {
   /*0x38*/ const void* extra_data;
   void* history_table;
   uint32_t scope_index;
+  symbol* cookie;
 };
 
 dispatcher_context make_context(symbol* cookie_,

--- a/runtime/src/exc_engine/x64/throw.hpp
+++ b/runtime/src/exc_engine/x64/throw.hpp
@@ -20,13 +20,13 @@ struct dispatcher_context {
   const byte* handler;
   /*0x38*/ const void* extra_data;
   void* history_table;
-  uint32_t scope_index;
+  /*0x48*/ uint32_t scope_index;
   symbol* cookie;
 };
 
-dispatcher_context make_context(symbol* cookie_,
-                                throw_frame& frame_,
-                                const frame_walk_pdata& pdata_) noexcept;
+dispatcher_context make_context(symbol* cookie,
+                                throw_frame& frame,
+                                const frame_walk_pdata& pdata) noexcept;
 }  // namespace ktl::crt::exc_engine::x64
 
 #pragma once

--- a/runtime/src/exc_engine/x64/unwind_handler.cpp
+++ b/runtime/src/exc_engine/x64/unwind_handler.cpp
@@ -123,7 +123,7 @@ uint64_t& frame_walk_context::gp(uint8_t idx) noexcept {
   };
   const int8_t offs = conv[idx];
   if (offs < 0) {
-    set_termination_context({BugCheckReason::CorruptedEhUnwindData, offs});
+    set_termination_context({BugCheckReason::CorruptedMachineState, offs});
     terminate();
   }
   return (&rbx)[offs];
@@ -131,7 +131,7 @@ uint64_t& frame_walk_context::gp(uint8_t idx) noexcept {
 
 static xmm_register& get_xmm(frame_walk_context& ctx, uint8_t idx) noexcept {
   if (idx < 6 || idx >= 16) {
-    set_termination_context({BugCheckReason::CorruptedEhUnwindData, idx});
+    set_termination_context({BugCheckReason::CorruptedMachineState, idx});
     terminate();
   }
   return (&ctx.xmm6)[idx - 6];

--- a/runtime/src/exc_engine/x64/unwind_handler.cpp
+++ b/runtime/src/exc_engine/x64/unwind_handler.cpp
@@ -141,9 +141,8 @@ void frame_walk_pdata::unwind(const unwind_info& unwind_info,
                               frame_walk_context& ctx,
                               machine_frame& mach) const noexcept {
   bool rip_updated = false;
-  for (uint32_t idx = 0; idx < unwind_info.unwind_code_count; ++idx) {
-    const auto& entry = unwind_info.entries[idx];
-    switch (entry.code) {
+  for (uint32_t idx = 0; idx < unwind_info.code_count; ++idx) {
+    switch (const auto& entry = unwind_info.entries[idx]; entry.code) {
       case UnwindCode::PushNonVolatileReg:
         ctx.gp(entry.info) = *reinterpret_cast<const uint64_t*>(mach.rsp);
         mach.rsp += 8;


### PR DESCRIPTION
* Fixed destroying objects created using aggregate initialization
* Improved code quality of the EH dispatcher
* `ktl::terminate()` can be called at any IRQL