### PR TITLE
Fixed comparison operators for smart pointers

### DIFF
--- a/include/hash.hpp
+++ b/include/hash.hpp
@@ -111,8 +111,15 @@ struct hash<shared_ptr<Ty>> {
   }
 };
 
+template <class Ty>
+struct hash<intrusive_ptr<Ty>> {
+  size_t operator()(const intrusive_ptr<Ty>& ptr) const noexcept {
+    return hash_int(reinterpret_cast<size_t>(ptr.get()));
+  }
+};
+
 template <typename Enum>
-struct hash<Enum, typename enable_if_t<is_enum_v<Enum>>> {
+struct hash<Enum, enable_if_t<is_enum_v<Enum>>> {
   size_t operator()(Enum e) const noexcept {
     using underlying_t = underlying_type_t<Enum>;
     return hash<underlying_t>{}(static_cast<underlying_t>(e));

--- a/include/smart_pointer.hpp
+++ b/include/smart_pointer.hpp
@@ -214,7 +214,10 @@ class unique_ptr {
 template <class Ty1, class Dx1, class Ty2, class Dx2>
 constexpr bool operator==(const unique_ptr<Ty1, Dx1>& lhs,
                           const unique_ptr<Ty2, Dx2>& rhs) noexcept {
-  return lhs.get() == rhs.get();
+  using common_t = common_type_t<typename unique_ptr<Ty1, Dx1>::pointer,
+                                 typename unique_ptr<Ty2, Dx2>::pointer>;
+  return equal_to<common_t>{}(static_cast<common_t>(lhs.get()),
+                              static_cast<common_t>(rhs.get()));
 }
 
 template <class Ty1, class Dx1, class Ty2, class Dx2>

--- a/include/smart_pointer.hpp
+++ b/include/smart_pointer.hpp
@@ -1492,6 +1492,24 @@ constexpr bool operator<(const intrusive_ptr<Ty>& lhs,
                               static_cast<common_ptr_t>(rhs.get()));
 }
 
+template <class Ty, class U>
+constexpr bool operator>(const intrusive_ptr<Ty>& lhs,
+                         const intrusive_ptr<U>& rhs) noexcept {
+  return rhs < lhs;
+}
+
+template <class Ty, class U>
+constexpr bool operator<=(const intrusive_ptr<Ty>& lhs,
+                          const intrusive_ptr<U>& rhs) noexcept {
+  return !(lhs > rhs);
+}
+
+template <class Ty, class U>
+constexpr bool operator>=(const intrusive_ptr<Ty>& lhs,
+                          const intrusive_ptr<U>& rhs) noexcept {
+  return !(lhs < rhs);
+}
+
 template <class Ty>
 constexpr void swap(intrusive_ptr<Ty>& lhs, intrusive_ptr<Ty>& rhs) noexcept {
   lhs.swap(rhs);

--- a/include/smart_pointer.hpp
+++ b/include/smart_pointer.hpp
@@ -318,6 +318,11 @@ constexpr bool operator>=(nullptr_t null,
   return !(null < ptr);
 }
 
+template <class Ty, class Dx>
+constexpr Ty* get_pointer(const unique_ptr<Ty, Dx>& ptr) noexcept {
+  return ptr.get();
+}
+
 // C++17 deduction guide
 template <class Ty>
 unique_ptr(Ty*) -> unique_ptr<Ty>;
@@ -1117,7 +1122,7 @@ shared_ptr<Ty> weak_ptr<Ty>::lock() const noexcept {
 }
 
 template <class Ty1, class Ty2>
-bool operator==(const shared_ptr<Ty1>& lhs,
+constexpr bool operator==(const shared_ptr<Ty1>& lhs,
                 const shared_ptr<Ty2>& rhs) noexcept {
   using common_t = common_type_t<typename shared_ptr<Ty1>::pointer,
                                  typename shared_ptr<Ty2>::pointer>;
@@ -1126,13 +1131,13 @@ bool operator==(const shared_ptr<Ty1>& lhs,
 }
 
 template <class Ty1, class Ty2>
-bool operator!=(const shared_ptr<Ty1>& lhs,
+constexpr bool operator!=(const shared_ptr<Ty1>& lhs,
                 const shared_ptr<Ty2>& rhs) noexcept {
   return !(lhs == rhs);
 }
 
 template <class Ty1, class Ty2>
-bool operator<(const shared_ptr<Ty1>& lhs,
+constexpr bool operator<(const shared_ptr<Ty1>& lhs,
                const shared_ptr<Ty2>& rhs) noexcept {
   using common_t = common_type_t<typename shared_ptr<Ty1>::pointer,
                                  typename shared_ptr<Ty2>::pointer>;
@@ -1141,85 +1146,85 @@ bool operator<(const shared_ptr<Ty1>& lhs,
 }
 
 template <class Ty1, class Ty2>
-bool operator>(const shared_ptr<Ty1>& lhs,
+constexpr bool operator>(const shared_ptr<Ty1>& lhs,
                const shared_ptr<Ty2>& rhs) noexcept {
   return rhs < lhs;
 }
 
 template <class Ty1, class Ty2>
-bool operator<=(const shared_ptr<Ty1>& lhs,
+constexpr bool operator<=(const shared_ptr<Ty1>& lhs,
                 const shared_ptr<Ty2>& rhs) noexcept {
   return !(lhs > rhs);
 }
 
 template <class Ty1, class Ty2>
-bool operator>=(const shared_ptr<Ty1>& lhs,
+constexpr bool operator>=(const shared_ptr<Ty1>& lhs,
                 const shared_ptr<Ty2>& rhs) noexcept {
   return !(lhs < rhs);
 }
 
 template <class Ty>
-bool operator==(const shared_ptr<Ty>& ptr, nullptr_t) noexcept {
+constexpr bool operator==(const shared_ptr<Ty>& ptr, nullptr_t) noexcept {
   return !ptr;
 }
 
 template <class Ty>
-bool operator!=(const shared_ptr<Ty>& ptr, nullptr_t) noexcept {
+constexpr bool operator!=(const shared_ptr<Ty>& ptr, nullptr_t) noexcept {
   return ptr;
 }
 
 template <class Ty>
-bool operator==(nullptr_t, const shared_ptr<Ty>& ptr) noexcept {
+constexpr bool operator==(nullptr_t, const shared_ptr<Ty>& ptr) noexcept {
   return !ptr;
 }
 
 template <class Ty>
-bool operator!=(nullptr_t, const shared_ptr<Ty>& ptr) noexcept {
+constexpr bool operator!=(nullptr_t, const shared_ptr<Ty>& ptr) noexcept {
   return ptr;
 }
 
 template <class Ty>
-bool operator<(const shared_ptr<Ty>& ptr, nullptr_t null) noexcept {
+constexpr bool operator<(const shared_ptr<Ty>& ptr, nullptr_t null) noexcept {
   return less<const Ty*>{}(ptr.get(), null);
 }
 
 template <class Ty>
-bool operator>(const shared_ptr<Ty>& ptr, nullptr_t null) noexcept {
+constexpr bool operator>(const shared_ptr<Ty>& ptr, nullptr_t null) noexcept {
   return greater<const Ty*>{}(ptr.get(), null);
 }
 
 template <class Ty>
-bool operator<(nullptr_t null, const shared_ptr<Ty>& ptr) noexcept {
+constexpr bool operator<(nullptr_t null, const shared_ptr<Ty>& ptr) noexcept {
   return less<add_const<Ty> >(null, ptr.get());
 }
 
 template <class Ty>
-bool operator>(nullptr_t null, const shared_ptr<Ty>& ptr) noexcept {
+constexpr bool operator>(nullptr_t null, const shared_ptr<Ty>& ptr) noexcept {
   return greater<add_const_t<Ty> >(null, ptr.get());
 }
 
 template <class Ty>
-bool operator<=(const shared_ptr<Ty>& ptr, nullptr_t null) noexcept {
+constexpr bool operator<=(const shared_ptr<Ty>& ptr, nullptr_t null) noexcept {
   return !(ptr > null);
 }
 
 template <class Ty>
-bool operator<=(nullptr_t null, const shared_ptr<Ty>& ptr) noexcept {
+constexpr bool operator<=(nullptr_t null, const shared_ptr<Ty>& ptr) noexcept {
   return !(null > ptr);
 }
 
 template <class Ty>
-bool operator>=(const shared_ptr<Ty>& ptr, nullptr_t null) noexcept {
+constexpr bool operator>=(const shared_ptr<Ty>& ptr, nullptr_t null) noexcept {
   return !(ptr < null);
 }
 
 template <class Ty>
-bool operator>=(nullptr_t null, const shared_ptr<Ty>& ptr) noexcept {
+constexpr bool operator>=(nullptr_t null, const shared_ptr<Ty>& ptr) noexcept {
   return !(null < ptr);
 }
 
 template <class Ty>
-Ty* get_pointer(const shared_ptr<Ty>& ptr) noexcept {
+constexpr Ty* get_pointer(const shared_ptr<Ty>& ptr) noexcept {
   return ptr.get();
 }
 

--- a/include/smart_pointer.hpp
+++ b/include/smart_pointer.hpp
@@ -989,7 +989,7 @@ class shared_ptr
   }
 
   size_t use_count() const noexcept { return MyBase::use_count(); }
-  constexpr operator bool() const noexcept { return get() != nullptr; }
+  constexpr explicit operator bool() const noexcept { return get() != nullptr; }
 
  protected:
   template <class ValTy, class... Types>
@@ -1356,7 +1356,7 @@ class intrusive_ptr {
                 "intrusive_ptr_release()");
 
  public:
-  intrusive_ptr() noexcept = default;
+  constexpr intrusive_ptr() noexcept = default;
 
   intrusive_ptr(Ty* ptr, bool add_ref = true) : m_ptr{ptr} {
     if (ptr && add_ref) {
@@ -1370,7 +1370,8 @@ class intrusive_ptr {
     }
   }
 
-  intrusive_ptr(intrusive_ptr&& other) noexcept : m_ptr{other.detach()} {}
+  constexpr intrusive_ptr(intrusive_ptr&& other) noexcept
+      : m_ptr{other.detach()} {}
 
   template <class U, enable_if_t<is_convertible_v<U*, Ty*>, int> = 0>
   intrusive_ptr(const intrusive_ptr<U>& other)
@@ -1381,7 +1382,7 @@ class intrusive_ptr {
   }
 
   template <class U, enable_if_t<is_convertible_v<U*, Ty*>, int> = 0>
-  intrusive_ptr(intrusive_ptr<U>&& other) noexcept
+  constexpr intrusive_ptr(intrusive_ptr<U>&& other) noexcept
       : m_ptr{static_cast<Ty*>(other.detach())} {}
 
   ~intrusive_ptr() noexcept {
@@ -1426,23 +1427,25 @@ class intrusive_ptr {
   void reset(Ty* ptr = nullptr) { intrusive_ptr{ptr}.swap(*this); }
   void reset(Ty* ptr, bool add_ref) { intrusive_ptr{ptr, add_ref}.swap(*this); }
 
-  Ty& operator*() const& noexcept { return *m_ptr; }
-  Ty&& operator*() const&& noexcept { return move(*m_ptr); }
-  Ty* operator->() const noexcept { return m_ptr; }
-  Ty* get() const noexcept { return m_ptr; }
+  constexpr Ty& operator*() const& noexcept { return *m_ptr; }
+  constexpr Ty&& operator*() const&& noexcept { return move(*m_ptr); }
+  constexpr Ty* operator->() const noexcept { return m_ptr; }
+  constexpr Ty* get() const noexcept { return m_ptr; }
 
-  Ty* detach() noexcept { return exchange(m_ptr, nullptr); }
+  constexpr Ty* detach() noexcept { return exchange(m_ptr, nullptr); }
 
-  explicit operator bool() const noexcept { return m_ptr != nullptr; }
+  constexpr explicit operator bool() const noexcept { return m_ptr != nullptr; }
 
-  void swap(intrusive_ptr& other) noexcept { ktl::swap(m_ptr, other.m_ptr); }
+  constexpr void swap(intrusive_ptr& other) noexcept {
+    ktl::swap(m_ptr, other.m_ptr);
+  }
 
  private:
   Ty* m_ptr{nullptr};
 };
 
 template <class Ty, class U>
-bool operator==(const intrusive_ptr<Ty>& lhs,
+constexpr bool operator==(const intrusive_ptr<Ty>& lhs,
                 const intrusive_ptr<U>& rhs) noexcept {
   using common_ptr_t = common_type_t<const Ty*, const U*>;
   return equal_to<common_ptr_t>{}(static_cast<common_ptr_t>(lhs.get()),
@@ -1450,33 +1453,33 @@ bool operator==(const intrusive_ptr<Ty>& lhs,
 }
 
 template <class Ty, class U>
-bool operator!=(const intrusive_ptr<Ty>& lhs,
+constexpr bool operator!=(const intrusive_ptr<Ty>& lhs,
                 const intrusive_ptr<U>& rhs) noexcept {
   return !(lhs == rhs);
 }
 
 template <class Ty>
-bool operator==(const intrusive_ptr<Ty>& lhs, Ty* rhs) noexcept {
+constexpr bool operator==(const intrusive_ptr<Ty>& lhs, Ty* rhs) noexcept {
   return equal_to<const Ty*>{}(lhs.get(), rhs);
 }
 
 template <class Ty>
-bool operator!=(const intrusive_ptr<Ty>& lhs, Ty* rhs) noexcept {
+constexpr bool operator!=(const intrusive_ptr<Ty>& lhs, Ty* rhs) noexcept {
   return !(lhs == rhs);
 }
 
 template <class Ty>
-bool operator==(Ty* lhs, const intrusive_ptr<Ty>& rhs) noexcept {
+constexpr bool operator==(Ty* lhs, const intrusive_ptr<Ty>& rhs) noexcept {
   return rhs == lhs;
 }
 
 template <class Ty>
-bool operator!=(Ty* lhs, intrusive_ptr<Ty> const& rhs) noexcept {
+constexpr bool operator!=(Ty* lhs, intrusive_ptr<Ty> const& rhs) noexcept {
   return rhs != lhs;
 }
 
 template <class Ty, class U>
-bool operator<(const intrusive_ptr<Ty>& lhs,
+constexpr bool operator<(const intrusive_ptr<Ty>& lhs,
                const intrusive_ptr<U>& rhs) noexcept {
   using common_ptr_t = common_type_t<const Ty*, const U*>;
   return less<common_ptr_t>{}(static_cast<common_ptr_t>(lhs.get()),
@@ -1484,12 +1487,12 @@ bool operator<(const intrusive_ptr<Ty>& lhs,
 }
 
 template <class Ty>
-void swap(intrusive_ptr<Ty>& lhs, intrusive_ptr<Ty>& rhs) noexcept {
+constexpr void swap(intrusive_ptr<Ty>& lhs, intrusive_ptr<Ty>& rhs) noexcept {
   lhs.swap(rhs);
 }
 
 template <class Ty>
-Ty* get_pointer(const intrusive_ptr<Ty>& ptr) noexcept {
+constexpr Ty* get_pointer(const intrusive_ptr<Ty>& ptr) noexcept {
   return ptr.get();
 }
 

--- a/include/smart_pointer.hpp
+++ b/include/smart_pointer.hpp
@@ -90,8 +90,8 @@ class unique_ptr {
   template <
       class Dx = Deleter,
       enable_if_t<!is_reference_v<Dx> && is_move_constructible_v<Dx>, int> = 0>
-  constexpr unique_ptr(pointer ptr,
-             Deleter&& deleter) noexcept(is_nothrow_move_constructible_v<Dx>)
+  constexpr unique_ptr(pointer ptr, Deleter&& deleter) noexcept(
+      is_nothrow_move_constructible_v<Dx>)
       : m_value{move(deleter), ptr} {}
 
   // Dx is a reference type
@@ -213,19 +213,19 @@ class unique_ptr {
 
 template <class Ty1, class Dx1, class Ty2, class Dx2>
 constexpr bool operator==(const unique_ptr<Ty1, Dx1>& lhs,
-                const unique_ptr<Ty2, Dx2>& rhs) noexcept {
+                          const unique_ptr<Ty2, Dx2>& rhs) noexcept {
   return lhs.get() == rhs.get();
 }
 
 template <class Ty1, class Dx1, class Ty2, class Dx2>
 constexpr bool operator!=(const unique_ptr<Ty1, Dx1>& lhs,
-                const unique_ptr<Ty1, Dx2>& rhs) noexcept {
+                          const unique_ptr<Ty1, Dx2>& rhs) noexcept {
   return !(lhs == rhs);
 }
 
 template <class Ty1, class Dx1, class Ty2, class Dx2>
 constexpr bool operator<(const unique_ptr<Ty1, Dx1>& lhs,
-               const unique_ptr<Ty2, Dx2>& rhs) noexcept {
+                         const unique_ptr<Ty2, Dx2>& rhs) noexcept {
   using common_t = common_type_t<typename unique_ptr<Ty1, Dx1>::pointer,
                                  typename unique_ptr<Ty2, Dx2>::pointer>;
   return less<common_t>{}(static_cast<common_t>(lhs.get()),
@@ -234,19 +234,19 @@ constexpr bool operator<(const unique_ptr<Ty1, Dx1>& lhs,
 
 template <class Ty1, class Dx1, class Ty2, class Dx2>
 constexpr bool operator>(const unique_ptr<Ty1, Dx1>& lhs,
-               const unique_ptr<Ty2, Dx2>& rhs) noexcept {
+                         const unique_ptr<Ty2, Dx2>& rhs) noexcept {
   return rhs < lhs;
 }
 
 template <class Ty1, class Dx1, class Ty2, class Dx2>
 constexpr bool operator<=(const unique_ptr<Ty1, Dx1>& lhs,
-                const unique_ptr<Ty2, Dx2>& rhs) noexcept {
+                          const unique_ptr<Ty2, Dx2>& rhs) noexcept {
   return !(lhs > rhs);
 }
 
 template <class Ty1, class Dx1, class Ty2, class Dx2>
 constexpr bool operator>=(const unique_ptr<Ty1, Dx1>& lhs,
-                const unique_ptr<Ty2, Dx2>& rhs) noexcept {
+                          const unique_ptr<Ty2, Dx2>& rhs) noexcept {
   return !(lhs < rhs);
 }
 
@@ -1123,7 +1123,7 @@ shared_ptr<Ty> weak_ptr<Ty>::lock() const noexcept {
 
 template <class Ty1, class Ty2>
 constexpr bool operator==(const shared_ptr<Ty1>& lhs,
-                const shared_ptr<Ty2>& rhs) noexcept {
+                          const shared_ptr<Ty2>& rhs) noexcept {
   using common_t = common_type_t<typename shared_ptr<Ty1>::pointer,
                                  typename shared_ptr<Ty2>::pointer>;
   return equal_to<common_t>{}(static_cast<common_t>(lhs.get()),
@@ -1132,13 +1132,13 @@ constexpr bool operator==(const shared_ptr<Ty1>& lhs,
 
 template <class Ty1, class Ty2>
 constexpr bool operator!=(const shared_ptr<Ty1>& lhs,
-                const shared_ptr<Ty2>& rhs) noexcept {
+                          const shared_ptr<Ty2>& rhs) noexcept {
   return !(lhs == rhs);
 }
 
 template <class Ty1, class Ty2>
 constexpr bool operator<(const shared_ptr<Ty1>& lhs,
-               const shared_ptr<Ty2>& rhs) noexcept {
+                         const shared_ptr<Ty2>& rhs) noexcept {
   using common_t = common_type_t<typename shared_ptr<Ty1>::pointer,
                                  typename shared_ptr<Ty2>::pointer>;
   return less<common_t>{}(static_cast<common_t>(lhs.get()),
@@ -1147,19 +1147,19 @@ constexpr bool operator<(const shared_ptr<Ty1>& lhs,
 
 template <class Ty1, class Ty2>
 constexpr bool operator>(const shared_ptr<Ty1>& lhs,
-               const shared_ptr<Ty2>& rhs) noexcept {
+                         const shared_ptr<Ty2>& rhs) noexcept {
   return rhs < lhs;
 }
 
 template <class Ty1, class Ty2>
 constexpr bool operator<=(const shared_ptr<Ty1>& lhs,
-                const shared_ptr<Ty2>& rhs) noexcept {
+                          const shared_ptr<Ty2>& rhs) noexcept {
   return !(lhs > rhs);
 }
 
 template <class Ty1, class Ty2>
 constexpr bool operator>=(const shared_ptr<Ty1>& lhs,
-                const shared_ptr<Ty2>& rhs) noexcept {
+                          const shared_ptr<Ty2>& rhs) noexcept {
   return !(lhs < rhs);
 }
 
@@ -1358,13 +1358,13 @@ class intrusive_ptr {
  public:
   constexpr intrusive_ptr() noexcept = default;
 
-  intrusive_ptr(Ty* ptr, bool add_ref = true) : m_ptr{ptr} {
+  constexpr intrusive_ptr(Ty* ptr, bool add_ref = true) : m_ptr{ptr} {
     if (ptr && add_ref) {
       intrusive_ptr_add_ref(get());
     }
   }
 
-  intrusive_ptr(const intrusive_ptr& other) : m_ptr{other.get()} {
+  constexpr intrusive_ptr(const intrusive_ptr& other) : m_ptr{other.get()} {
     if (auto* ptr = get(); ptr) {
       intrusive_ptr_add_ref(ptr);
     }
@@ -1374,7 +1374,7 @@ class intrusive_ptr {
       : m_ptr{other.detach()} {}
 
   template <class U, enable_if_t<is_convertible_v<U*, Ty*>, int> = 0>
-  intrusive_ptr(const intrusive_ptr<U>& other)
+  constexpr intrusive_ptr(const intrusive_ptr<U>& other)
       : m_ptr{static_cast<Ty*>(other.get())} {
     if (auto* ptr = get(); ptr) {
       intrusive_ptr_add_ref(ptr);
@@ -1385,20 +1385,20 @@ class intrusive_ptr {
   constexpr intrusive_ptr(intrusive_ptr<U>&& other) noexcept
       : m_ptr{static_cast<Ty*>(other.detach())} {}
 
-  ~intrusive_ptr() noexcept {
+  constexpr ~intrusive_ptr() noexcept {
     if (auto* ptr = get(); ptr) {
       intrusive_ptr_release(ptr);
     }
   }
 
-  intrusive_ptr& operator=(const intrusive_ptr& other) {
+  constexpr intrusive_ptr& operator=(const intrusive_ptr& other) {
     if (this != addressof(other)) {
       intrusive_ptr{other}.swap(*this);
     }
     return *this;
   }
 
-  intrusive_ptr& operator=(intrusive_ptr&& other) noexcept {
+  constexpr intrusive_ptr& operator=(intrusive_ptr&& other) noexcept {
     if (this != addressof(other)) {
       reset(other.detach(), false);
     }
@@ -1406,26 +1406,29 @@ class intrusive_ptr {
   }
 
   template <class U>
-  intrusive_ptr& operator=(const intrusive_ptr<U>& other) {
+  constexpr intrusive_ptr& operator=(const intrusive_ptr<U>& other) {
     intrusive_ptr{other}.swap(*this);
     return *this;
   }
 
   template <class U>
-  intrusive_ptr& operator=(intrusive_ptr<U>&& other) noexcept {
+  constexpr intrusive_ptr& operator=(intrusive_ptr<U>&& other) noexcept {
     if (this != addressof(other)) {
       reset(static_cast<Ty*>(other.detach(), false));
     }
     return *this;
   }
 
-  intrusive_ptr& operator=(Ty* ptr) {
+  constexpr intrusive_ptr& operator=(Ty* ptr) {
     reset(ptr);
     return *this;
   }
 
-  void reset(Ty* ptr = nullptr) { intrusive_ptr{ptr}.swap(*this); }
-  void reset(Ty* ptr, bool add_ref) { intrusive_ptr{ptr, add_ref}.swap(*this); }
+  constexpr void reset(Ty* ptr = nullptr) { intrusive_ptr{ptr}.swap(*this); }
+
+  constexpr void reset(Ty* ptr, bool add_ref) {
+    intrusive_ptr{ptr, add_ref}.swap(*this);
+  }
 
   constexpr Ty& operator*() const& noexcept { return *m_ptr; }
   constexpr Ty&& operator*() const&& noexcept { return move(*m_ptr); }
@@ -1446,7 +1449,7 @@ class intrusive_ptr {
 
 template <class Ty, class U>
 constexpr bool operator==(const intrusive_ptr<Ty>& lhs,
-                const intrusive_ptr<U>& rhs) noexcept {
+                          const intrusive_ptr<U>& rhs) noexcept {
   using common_ptr_t = common_type_t<const Ty*, const U*>;
   return equal_to<common_ptr_t>{}(static_cast<common_ptr_t>(lhs.get()),
                                   static_cast<common_ptr_t>(rhs.get()));
@@ -1454,7 +1457,7 @@ constexpr bool operator==(const intrusive_ptr<Ty>& lhs,
 
 template <class Ty, class U>
 constexpr bool operator!=(const intrusive_ptr<Ty>& lhs,
-                const intrusive_ptr<U>& rhs) noexcept {
+                          const intrusive_ptr<U>& rhs) noexcept {
   return !(lhs == rhs);
 }
 
@@ -1480,7 +1483,7 @@ constexpr bool operator!=(Ty* lhs, intrusive_ptr<Ty> const& rhs) noexcept {
 
 template <class Ty, class U>
 constexpr bool operator<(const intrusive_ptr<Ty>& lhs,
-               const intrusive_ptr<U>& rhs) noexcept {
+                         const intrusive_ptr<U>& rhs) noexcept {
   using common_ptr_t = common_type_t<const Ty*, const U*>;
   return less<common_ptr_t>{}(static_cast<common_ptr_t>(lhs.get()),
                               static_cast<common_ptr_t>(rhs.get()));


### PR DESCRIPTION
* Added `ktl::hash` specialization for `intrusive_ptr`
* Added `get_pointer` specialization for `unique_ptr`
* `unique_ptr` and `intrusive_ptr` are allowed to be used in `constexpr` expressions
* All comparison operators become `constexpr`
* Fixed `explicit` specifiers for `operator bool`
* Fixed compile errors