### PR TITLE
Fixed MSVC warnings when FMT_COMPILE is used extensively

### DIFF
--- a/modules/fmt/compile.hpp
+++ b/modules/fmt/compile.hpp
@@ -592,6 +592,7 @@ template <typename S,
           FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
 inline ktl::basic_winnt_string<typename S::char_type> format(const S&,
                                                              Args&&... args) {
+  constexpr auto compiled = detail::compile<Args...>(S());
   if constexpr (ktl::is_same<typename S::char_type, char>::value) {
     constexpr auto str = basic_winnt_string_view<typename S::char_type>(S());
     if constexpr (str.size() == 2 && str[0] == '{' && str[1] == '}') {
@@ -603,10 +604,8 @@ inline ktl::basic_winnt_string<typename S::char_type> format(const S&,
         return fmt::to_string(first);
       }
     }
-  }
-  constexpr auto compiled = detail::compile<Args...>(S());
-  if constexpr (ktl::is_same<remove_cvref_t<decltype(compiled)>,
-                             detail::unknown_format>()) {
+  } else if constexpr (ktl::is_same<remove_cvref_t<decltype(compiled)>,
+                                    detail::unknown_format>()) {
     return format(
         static_cast<basic_winnt_string_view<typename S::char_type>>(S()),
         ktl::forward<Args>(args)...);

--- a/modules/fmt/core.hpp
+++ b/modules/fmt/core.hpp
@@ -878,7 +878,7 @@ class iterator_buffer<ktl::back_insert_iterator<Container>,
 
  protected:
   void grow(size_t capacity) final FMT_OVERRIDE {
-    container_.resize(capacity);
+    container_.resize(static_cast<typename Container::size_type>(capacity));
     this->set(&container_[0], capacity);
   }
 
@@ -2037,9 +2037,7 @@ class dynamic_specs_handler
     specs_.precision_ref = make_arg_ref(arg_id);
   }
 
-  constexpr void on_error(const char* message) {
-    context_.on_error(message);
-  }
+  constexpr void on_error(const char* message) { context_.on_error(message); }
 
  private:
   dynamic_format_specs<char_type>& specs_;
@@ -2779,9 +2777,7 @@ class format_string_checker {
     return id >= 0 && id < num_args ? parse_funcs_[id](context_) : begin;
   }
 
-  constexpr void on_error(const char* message) {
-    context_.on_error(message);
-  }
+  constexpr void on_error(const char* message) { context_.on_error(message); }
 };
 
 template <typename... Args,


### PR DESCRIPTION
* Added explicit cast from `size_t` to `typename Container::size_type` in `resize` (this conversion may be narrowing)
* `if constexpr/if constexpr` pair replaced by `if constexpr/else if constexpr` due to MSVC bug