### PR TITLE
Addded workaround for the MSVC linker bug with LTO enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ set(
 )
 set(
 	RELEASE_LINK_OPTIONS
-		/OPT:REF							# Eliminate unused code
+		/OPT:REF						# Eliminate unused code
 		/INCLUDE:verify_seh					# Force include symbols erroneously eliminated due to a bug in LTO (MSVC <= 16.29)
 		/INCLUDE:verify_seh_in_cxx_handler
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,9 @@ endif()
 
 set(
 	BASIC_COMPILE_OPTIONS
-		/MP	# Multiprocessor compilation
-		/W4 # Warnings level
-		/WX # Treat warnings as errors
+		/MP		# Multiprocessor compilation
+		/W4		# Warnings level
+		/WX		# Treat warnings as errors
 )
 set(
 	RELEASE_COMPILE_OPTIONS
@@ -37,9 +37,7 @@ set(
 )
 set(
 	RELEASE_LINK_OPTIONS
-		/OPT:REF						# Eliminate unused code
-		/INCLUDE:verify_seh					# Force include symbols erroneously eliminated due to a bug in LTO (MSVC <= 16.29)
-		/INCLUDE:verify_seh_in_cxx_handler
+		/OPT:REF							# Eliminate unused code
 )
 set(
 	LTO_LINK_OPTIONS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,9 @@ set(
 )
 set(
 	RELEASE_LINK_OPTIONS
-		/OPT:REF			# Eliminate unused code
+		/OPT:REF							# Eliminate unused code
+		/INCLUDE:verify_seh					# Force include symbols erroneously eliminated due to a bug in LTO (MSVC <= 16.29)
+		/INCLUDE:verify_seh_in_cxx_handler
 )
 set(
 	LTO_LINK_OPTIONS

--- a/modules/fmt/compile.hpp
+++ b/modules/fmt/compile.hpp
@@ -592,7 +592,6 @@ template <typename S,
           FMT_ENABLE_IF(detail::is_compiled_string<S>::value)>
 inline ktl::basic_winnt_string<typename S::char_type> format(const S&,
                                                              Args&&... args) {
-  constexpr auto compiled = detail::compile<Args...>(S());
   if constexpr (ktl::is_same<typename S::char_type, char>::value) {
     constexpr auto str = basic_winnt_string_view<typename S::char_type>(S());
     if constexpr (str.size() == 2 && str[0] == '{' && str[1] == '}') {
@@ -604,8 +603,10 @@ inline ktl::basic_winnt_string<typename S::char_type> format(const S&,
         return fmt::to_string(first);
       }
     }
-  } else if constexpr (ktl::is_same<remove_cvref_t<decltype(compiled)>,
-                                    detail::unknown_format>()) {
+  }
+  constexpr auto compiled = detail::compile<Args...>(S());
+  if constexpr (ktl::is_same<remove_cvref_t<decltype(compiled)>,
+                             detail::unknown_format>()) {
     return format(
         static_cast<basic_winnt_string_view<typename S::char_type>>(S()),
         ktl::forward<Args>(args)...);

--- a/runtime/include/bugcheck.hpp
+++ b/runtime/include/bugcheck.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <basic_types.hpp>
+#include <crt_attributes.hpp>
 #include <irql.hpp>
 
 #include <ntddk.h>
@@ -58,13 +59,15 @@ struct termination_context {
 termination_context set_termination_context(
     const termination_context& bsod) noexcept;
 
-void verify_seh(NTSTATUS code, const void* addr, uint32_t flags) noexcept;
+EXTERN_C void verify_seh(NTSTATUS code,
+                         const void* addr,
+                         uint32_t flags) noexcept;
 
-void verify_seh_in_cxx_handler(NTSTATUS code,
-                               const void* addr,
-                               uint32_t flags,
-                               uint32_t unwind_info,
-                               const void* image_base) noexcept;
+EXTERN_C void verify_seh_in_cxx_handler(NTSTATUS code,
+                                        const void* addr,
+                                        uint32_t flags,
+                                        uint32_t unwind_info,
+                                        const void* image_base) noexcept;
 
 namespace details {
 class termination_dispatcher {

--- a/runtime/src/CMakeLists.txt
+++ b/runtime/src/CMakeLists.txt
@@ -50,11 +50,15 @@ target_compile_definitions(
 	${RUNTIME_LIB} PRIVATE
 		KTL_RUNTIME_DBG
 		KTL_NO_CXX_STANDARD_LIBRARY
-		_CRT_SECURE_CPP_OVERLOAD_SECURE_NAMES=0  # Для исправления ошибки с затемнением параметров шаблона в старых хедерах CRT
-)
+		_CRT_SECURE_CPP_OVERLOAD_SECURE_NAMES=0 # Workround for a bug with shadowing template parameters in old CRT headers 
+)		
 target_link_options(
 	${RUNTIME_LIB} PRIVATE
-		$<$<CONFIG:Release>:${RELEASE_LINK_OPTIONS}>
+		$<$<CONFIG:Release>:
+			${RELEASE_LINK_OPTIONS}
+			/INCLUDE:verify_seh					# Force include symbols erroneously eliminated due to a bug in LTO (MSVC <= 16.29)
+			/INCLUDE:verify_seh_in_cxx_handler
+		>
 		$<$<CONFIG:Release>:${LTO_LINK_OPTIONS}>
 )
 target_link_libraries(


### PR DESCRIPTION
* verify_seh() and verify_seh_in_cxx_handler() marked 'extern "C"'
* forced including of these symbols using /INCLUDE link option