### PR TITLE
The filesystem mini-filters support library has become part of the basic_runtime library as a separate TU

### DIFF
--- a/runtime/include/CMakeLists.txt
+++ b/runtime/include/CMakeLists.txt
@@ -5,7 +5,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(KTL_RUNTIME_INCLUDE_DIR "${KTL_RUNTIME_DIR}/include")
-set(KTL_MINIFILTER_RUNTIME_INCLUDE_DIR ${KTL_RUNTIME_INCLUDE_DIR})
 
 set(
 	KTL_RUNTIME_HEADER_FILES
@@ -26,6 +25,7 @@ set(
 		"irql.hpp"
 		"limits_impl.hpp"
 		"memory_type_traits_impl.hpp"
+		"minifilter.hpp"
 		"object_management.hpp"
 		"placement_new.hpp"
 		"preload_initializer.hpp"
@@ -34,13 +34,7 @@ set(
 		"utility_impl.hpp"
 )
 
-set(
-	KTL_MINIFILTER_RUNTIME_HEADER_FILES
-		"minifilter.hpp"
-)
-
 set(RUNTIME_LIB basic_runtime_interface)
-set(MINIFILTER_LIB minifilter_runtime_interface)
 
 add_subdirectory(exc_engine)
 
@@ -57,10 +51,4 @@ target_compile_definitions(
 	${RUNTIME_LIB} INTERFACE 
 		KTL_ENABLE_EXTENDED_ALIGNED_STORAGE
 		_CRT_SECURE_CPP_OVERLOAD_SECURE_NAMES=0  # Для исправления ошибки с затемнением параметров шаблона в старых хедерах CRT
-)
-
-add_library(${MINIFILTER_LIB} INTERFACE)
-target_include_directories(
-	${MINIFILTER_LIB} 
-		INTERFACE ${KTL_MINIFILTER_RUNTIME_INCLUDE_DIR}
 )

--- a/runtime/src/CMakeLists.txt
+++ b/runtime/src/CMakeLists.txt
@@ -18,18 +18,14 @@ set(
 		"floating_point.cpp" 
 		"irql.cpp"
 		"heap.cpp"
+		"minifilter.cpp"
 		"object_management.cpp"
 		"placement_new.cpp"
 		"preload_initializer.cpp"
 		"type_info.cpp"
 )
-set(
-	KTL_MINIFILTER_RUNTIME_SOURCE_FILES
-		"minifilter.cpp"
-)
 
 set(RUNTIME_LIB basic_runtime)
-set(MINIFILTER_LIB minifilter_runtime)
 
 add_subdirectory(exc_engine)
 
@@ -76,32 +72,4 @@ endif()
 target_link_options(
 	${RUNTIME_LIB} 
 		PRIVATE "/WHOLEARCHIVE"
-)
-
-wdk_add_library(
-	${MINIFILTER_LIB} STATIC 
-		WINVER ${TARGET_WINVER}
-		${KTL_RUNTIME_HEADER_FILES}	
-		${KTL_MINIFILTER_RUNTIME_SOURCE_FILES}
-)
-target_compile_options(
-	${MINIFILTER_LIB} PRIVATE
-		${BASIC_COMPILE_OPTIONS}
-		$<$<CONFIG:Release>:${RELEASE_COMPILE_OPTIONS}>
-		$<$<CONFIG:Release>:${LTO_COMPILE_OPTIONS}>
-)
-target_compile_definitions(
-	${MINIFILTER_LIB} PRIVATE
-		$<$<CONFIG:Debug>:KTL_RUNTIME_DBG>
-		KTL_NO_CXX_STANDARD_LIBRARY
-		_CRT_SECURE_CPP_OVERLOAD_SECURE_NAMES=0  # Для исправления ошибки с затемнением параметров шаблона в старых хедерах CRT
-)
-target_link_options(
-	${MINIFILTER_LIB} PRIVATE
-		$<$<CONFIG:Release>:${RELEASE_LINK_OPTIONS}>
-		$<$<CONFIG:Release>:${LTO_LINK_OPTIONS}>
-)
-target_link_libraries(
-	${MINIFILTER_LIB} 
-		PUBLIC minifilter_runtime_interface
 )

--- a/runtime/src/minifilter.cpp
+++ b/runtime/src/minifilter.cpp
@@ -7,7 +7,7 @@ namespace ktl::crt {
 namespace details {
 extern driver_context driver_ctx;
 static filter_context filter_ctx{};
-}
+}  // namespace details
 }  // namespace ktl::crt
 
 EXTERN_C NTSTATUS STDCALL
@@ -18,10 +18,10 @@ KtlRegisterFilter(DRIVER_OBJECT* driver_object,
   drv_unload = &KtlDriverUnload;
 
   auto& filter{ktl::crt::details::filter_ctx.object};
-  const NTSTATUS status{FltRegisterFilter(driver_object, &flt_registration, &filter)};
+  const NTSTATUS status{
+      FltRegisterFilter(driver_object, &flt_registration, &filter)};
   if (!NT_SUCCESS(status)) {
     filter = nullptr;
-    KdPrint(("Minifilter registration failed with status %#x", status));
   }
   return status;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,7 +43,6 @@ target_link_libraries(
 	ktl_test
 		basic_runtime 
 		cpp_runtime
-		minifilter_runtime
 
 		tests::dynamic_init
 		tests::exception_dispatcher


### PR DESCRIPTION
Closes #213